### PR TITLE
Fix broken date filters in the events page

### DIFF
--- a/src/APP/pages/events/sections/eventsSection/EventCategory.jsx
+++ b/src/APP/pages/events/sections/eventsSection/EventCategory.jsx
@@ -46,7 +46,6 @@ function EventCategory() {
 
   // Handle filter by recent buttons
   const filterRecents = (times) => {
-    console.log('Here');
     setFilters((prevState) => {
       return {
         ...prevState,

--- a/src/APP/pages/events/sections/eventsSection/EventCategory.jsx
+++ b/src/APP/pages/events/sections/eventsSection/EventCategory.jsx
@@ -46,10 +46,11 @@ function EventCategory() {
 
   // Handle filter by recent buttons
   const filterRecents = (times) => {
+    console.log('Here');
     setFilters((prevState) => {
       return {
         ...prevState,
-        date: filterRecentTime(times),
+        start_date: filterRecentTime(times),
       };
     });
     setSelectedRecentButton((prevState) => {

--- a/src/APP/pages/events/sections/eventsSection/EventsSection.jsx
+++ b/src/APP/pages/events/sections/eventsSection/EventsSection.jsx
@@ -33,7 +33,7 @@ function EventsSection({ showTabs, showAllEventsLink }) {
   const updateRecentFilter = (dateFilterString) => {
     setFilters((prevState) => ({
       ...prevState,
-      date: dateFilterString,
+      start_date: dateFilterString,
     }));
   };
 


### PR DESCRIPTION
This PR fixes the 'This Week,' 'Weekend,' 'Today,' and 'Recent' filter buttons on the All events page which broke after an update to the Backend API altering how date filters are executed.