### PR TITLE
Fix #138 Lazy Load all images on the website

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18.2.0",
     "react-fast-marquee": "^1.6.2",
     "react-hook-form": "^7.48.2",
+    "react-lazy-load-image-component": "^1.6.0",
     "react-photo-album": "^2.3.0",
     "react-router-dom": "^6.11.2",
     "react-share": "^5.1.0",

--- a/src/APP/components/Caroussel.jsx
+++ b/src/APP/components/Caroussel.jsx
@@ -1,3 +1,5 @@
+import { LazyLoadImage } from "react-lazy-load-image-component";
+
 function Caroussel({ CarousselData }) {
   return (
     <section className="pt-4 sm:pt-16 pb-10 mx-auto w-full max-w-screen-2xl pl-4 lg:pl-14 xl:pl-28">
@@ -15,10 +17,11 @@ function Caroussel({ CarousselData }) {
             key={index}
             className="relative after:block after:relative after:-mt-36 after:h-36 after:w-full after:content-[''] after:z-0 after:rounded-b-2xl after:bg-[linear-gradient(180deg,_rgba(0,0,0,0)_0%,_rgba(0,0,0,0.5)_29.17%,_rgba(0,0,0,0.94)_97.92%)]"
           >
-            <img
+            <LazyLoadImage
               className="rounded-2xl w-[300px] h-[300px] object-cover items-center"
               src={image}
               alt={name}
+              effect="blur"
             />
             <div className="absolute -translate-x-2/4 -translate-y-1/4 left-2/4 top-3/4 text-white text-center z-10 font-medium w-4/5">
               <p className="pb-2 text-xl">{name}</p>

--- a/src/APP/components/Footer.jsx
+++ b/src/APP/components/Footer.jsx
@@ -5,6 +5,7 @@ import {
   twitter,
 } from "../../assets/images/socials";
 import logo from "../../assets/images/sytLogo.png";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Footer() {
   var now = new Date();
@@ -15,27 +16,48 @@ function Footer() {
         <div className="md:flex md:justify-between">
           {/* logo and socials  */}
           <div className="mb-8 md:mb-0 mr-6 flex flex-col justify-start items-center md:w-1/4 w-1/2">
-            <img
+            <LazyLoadImage
               src={logo}
-              className="h-24 md:mx-8 mx-0 object-contain"
               alt="FlowBite Logo"
+              className="h-24 md:mx-8 mx-0 object-contain"
+              effect="blur"
             />
             {/* social logos  */}
             <div className="flex flex-row items-center  md:justify-between gap-4 justify-start my-4">
               <a href="/">
-                <img src={facebook} alt="facebook" className="w-7 h-7" />
+                <LazyLoadImage
+                  src={facebook}
+                  alt="facebook"
+                  className="w-7 h-7"
+                  effect="blur"
+                />
               </a>
 
               <a href="/">
-                <img src={instagram} alt="instagram" className="w-7 h-7" />
+                <LazyLoadImage
+                  src={instagram}
+                  alt="instagram"
+                  className="w-7 h-7"
+                  effect="blur"
+                />
               </a>
 
               <a href="/">
-                <img src={twitter} alt="twitter" className="w-7 h-7" />
+                <LazyLoadImage
+                  src={twitter}
+                  alt="twitter"
+                  className="w-7 h-7"
+                  effect="blur"
+                />
               </a>
 
               <a href="/">
-                <img src={linkedin} alt="linkedIn" className="w-7 h-7" />
+                <LazyLoadImage
+                  src={linkedin}
+                  alt="linkedIn"
+                  className="w-7 h-7"
+                  effect="blur"
+                />
               </a>
             </div>
           </div>

--- a/src/APP/components/Footer2.jsx
+++ b/src/APP/components/Footer2.jsx
@@ -10,6 +10,7 @@ import {
   instagram,
   facebook,
 } from "../../assets/images/socials";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Footer2() {
   const now = new Date();
@@ -21,12 +22,12 @@ function Footer2() {
         <div className="flex lg:flex-row flex-col md:gap-16 gap-8">
           <div className="flex-3 flex flex-col sm:items-start items-center">
             {/* logo */}
-            <img
+            <LazyLoadImage
               src={logo}
               alt="logo"
               className="w-[124px] h-32 md:ml-0 ml-4 object-contain"
+              effect="blur"
             />
-
             {/* socials */}
             <div className="flex flex-col items-center">
               <div className="flex items-center md:gap-5 gap-3 py-4">
@@ -35,21 +36,37 @@ function Footer2() {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <img src={facebook} alt="facebook" className="w-7 h-7" />
+                  <LazyLoadImage
+                    src={facebook}
+                    alt="facebook"
+                    className="w-7 h-7"
+                    effect="blur"
+                  />
                 </a>
                 <a
                   href="https://www.instagram.com/spaceyatech/"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <img src={instagram} alt="instagram" className="w-7 h-7" />
+                  <LazyLoadImage
+                    src={instagram}
+                    alt="instagram"
+                    className="w-7 h-7"
+                    effect="blur"
+                  />
+                  {/* < src={instagram} alt="instagram" className="w-7 h-7" /> */}
                 </a>
                 <a
                   href="https://x.com/SpaceYaTech"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <img src={twitter} alt="twitter" className="w-7 h-7" />
+                  <LazyLoadImage
+                    src={twitter}
+                    alt="twitter"
+                    className="w-7 h-7"
+                    effect="blur"
+                  />
                 </a>
 
                 <a
@@ -57,7 +74,12 @@ function Footer2() {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <img src={linkedin} alt="linkedin" className="w-7 h-7" />
+                  <LazyLoadImage
+                    src={linkedin}
+                    alt="linkedIn"
+                    className="w-7 h-7"
+                    effect="blur"
+                  />
                 </a>
               </div>
               <div className="flex items-center md:gap-5 gap-3">
@@ -66,7 +88,12 @@ function Footer2() {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <img src={youtube} alt="youtube" className="w-7 h-7" />
+                  <LazyLoadImage
+                    src={youtube}
+                    alt="youtube"
+                    className="w-7 h-7"
+                    effect="blur"
+                  />
                 </a>
 
                 <a
@@ -74,7 +101,12 @@ function Footer2() {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <img src={spotify} alt="spotify" className="w-7 h-7" />
+                  <LazyLoadImage
+                    src={spotify}
+                    alt="spotify"
+                    className="w-7 h-7"
+                    effect="blur"
+                  />
                 </a>
               </div>
             </div>
@@ -185,12 +217,12 @@ function Footer2() {
             &copy; {year} SpaceYaTech | All Rights Reserved
           </h1>
         </div>
-
-        {/* <img
-        src={backup}
-        alt="backup"
-        className="h-12 w-12 object-contain absolute sm:bottom-14 bottom-0 right-10 cursor-pointer"
-      /> */}
+        {/* <LazyLoadImage
+          src={backup}
+          alt="backup"
+          className="w-7 h-7"
+          effect="blur"
+        /> */}
       </div>
     </footer>
   );

--- a/src/APP/components/Header.jsx
+++ b/src/APP/components/Header.jsx
@@ -1,11 +1,17 @@
 import logo from "../../assets/images/sytLogo.png";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Header() {
   return (
     <header className="hidden md:block text-gray-600 body-font">
       <div className="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
         <a className="flex title-font font-medium items-center text-gray-900 mb-4 md:mb-0">
-          <img src={logo} className="h-24 mx-8" alt="Logo" />
+          <LazyLoadImage
+            src={logo}
+            alt="logo"
+            className="h-24 mx-8"
+            effect="blur"
+          />
         </a>
         <nav className="md:ml-auto flex flex-wrap items-center text-base justify-center">
           <a className="mr-5 hover:text-gray-900">Home</a>

--- a/src/APP/components/Header2.jsx
+++ b/src/APP/components/Header2.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 
 import logo from "../../assets/images/sytLogo.png";
 import menu from "../../assets/images/hamburger-menu.svg";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const navLinks = [
   {
@@ -56,17 +57,23 @@ const Header2 = () => {
     <header className="py-5 md:px-10 px-5 flex items-center justify-between md:shadow-none shadow-md relative max-w-[1440px] md:mx-auto">
       {/* logo */}
       <Link to="/">
-        <img src={logo} alt="logo" className="md:w-16 w-12" />
+        <LazyLoadImage
+          src={logo}
+          alt="logo"
+          className="md:w-16 w-12"
+          effect="blur"
+        />
       </Link>
 
       {/* mobile menu */}
-      <img
+      <LazyLoadImage
         src={menu}
         alt="logo"
         className="md:hidden"
         onClick={() => setShowNavlinks((prev) => !prev)}
+        effect="blur"
       />
-
+      
       {/* mobile navlinks */}
       <nav
         className="flex flex-col items-start justify-start gap-6 text-base absolute top-[90px] left-0 bg-white border-b w-full h-fit z-[1] p-5 pl-12"

--- a/src/APP/components/Loader.jsx
+++ b/src/APP/components/Loader.jsx
@@ -1,12 +1,15 @@
+import { LazyLoadImage } from "react-lazy-load-image-component";
+
 const Loader = () => {
   return (
     <div className="w-full flex items-center justify-center">
-      <img
+      <LazyLoadImage
         src="/loader.svg"
         width={60}
         height={60}
         alt="loader"
         className="object-contain"
+        effect="blur"
       />
     </div>
   );

--- a/src/APP/components/PodcastCard.jsx
+++ b/src/APP/components/PodcastCard.jsx
@@ -1,11 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function PodcastCard({ img, category = "Podcast", title, description, link }) {
   return (
     <a href={link} target="_blank" rel="noopener noreferrer" className="h-fit">
       <div className="w-[85vw] md:w-[350px] h-[380px] mx-4 rounded-md overflow-hidden relative">
-        <img src={img} alt={title} className="w-full h-full object-cover" />
+        <LazyLoadImage
+          src={img}
+          alt={title}
+          className="w-full h-full object-cover"
+          effect="blur"
+        />
         <div className="absolute bottom-0 left-0 right-0 bg-black opacity-80 h-1/2" />
 
         <div className="absolute bottom-0 inset-x-0 text-white flex flex-col gap-2 px-6 py-4">

--- a/src/APP/components/admin/AdminHeader.jsx
+++ b/src/APP/components/admin/AdminHeader.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import logo from "../../../assets/images/sytLogo.png";
 import bell from "../../../assets/images/icons/bell-icon.svg";
 import profile from "../../../assets/images/adminPage/profile-pic.png";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function AdminHeader() {
   return (
@@ -13,7 +14,12 @@ function AdminHeader() {
           {/* logo */}
 
           <Link to="/">
-            <img src={logo} alt="logo" className="md:w-16 w-12 md:hidden" />
+            <LazyLoadImage
+              src={logo}
+              alt="logo"
+              className="md:w-16 w-12 md:hidden"
+              effect="blur"
+            />
           </Link>
         </div>
         <div className="flex gap-5 items-center">
@@ -21,13 +27,18 @@ function AdminHeader() {
             className="transition-all duration-300 cursor-pointer"
             to="/notification"
           >
-            <img src={bell} alt="notification icon" />
+            <LazyLoadImage src={bell} alt="notification icon" effect="blur" />
           </Link>
           <Link
             className="transition-all duration-300 cursor-pointer"
             to="/profile"
           >
-            <img src={profile} alt="profile pic" className="rounded-full" />
+            <LazyLoadImage
+              src={profile}
+              alt="profile pic"
+              className="rounded-full"
+              effect="blur"
+            />
           </Link>
         </div>
       </nav>
@@ -38,7 +49,12 @@ function AdminHeader() {
           {/* logo */}
 
           <Link to="/">
-            <img src={logo} alt="logo" className="md:w-16 w-12" />
+            <LazyLoadImage
+              src={logo}
+              alt="logo"
+              className="md:w-16 w-12"
+              effect="blur"
+            />
           </Link>
         </div>
         <div className="md:flex flex-1 gap-12">
@@ -78,13 +94,18 @@ function AdminHeader() {
             className="text-[#7E8180] hover:text-primary transition-all duration-300 cursor-pointer"
             to="/"
           >
-            <img src={bell} alt="notification icon" />
+            <LazyLoadImage src={bell} alt="notification icon" effect="blur" />
           </Link>
           <Link
             className="text-[#7E8180] hover:text-primary transition-all duration-300 cursor-pointer"
             to="/about-us"
           >
-            <img src={profile} alt="profile pic" className="rounded-full" />
+            <LazyLoadImage
+              src={profile}
+              alt="profile pic"
+              className="rounded-full"
+              effect="blur"
+            />
           </Link>
         </div>
       </nav>

--- a/src/APP/components/admin/events/EventsTable.jsx
+++ b/src/APP/components/admin/events/EventsTable.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import SearchIcon from "../../../../assets/images/icons/search-icon.svg";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const initialData = [
   {
@@ -163,7 +164,7 @@ function EventsTable() {
             />
             <span className="sr-only">Search</span>
             <span className="absolute inset-y-0 right-1 flex items-center pr-2">
-              <img src={SearchIcon} alt="search" />
+              <LazyLoadImage src={SearchIcon} alt="search" effect="blur" />
             </span>
           </label>
         </div>

--- a/src/APP/components/shop/CartDrawer.jsx
+++ b/src/APP/components/shop/CartDrawer.jsx
@@ -9,6 +9,7 @@ import { useDeleteSwag } from "../../../hooks/Mutations/shop/useCartSwagg";
 import useProductsInCart from "../../../hooks/Queries/shop/useCartProducts";
 import useAuth from "../../../hooks/useAuth";
 import Counter from "./Counter";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function CartDrawer({ open, setOpen }) {
   const { auth } = useAuth();
@@ -72,7 +73,11 @@ function CartDrawer({ open, setOpen }) {
                           onClick={() => setOpen(false)}
                         >
                           <span className="sr-only">Close panel</span>
-                          <img src={CloseIcon} alt="close" />
+                          <LazyLoadImage
+                            src={CloseIcon}
+                            alt="close"
+                            effect="blur"
+                          />
                         </button>
                       </div>
                     </div>
@@ -100,10 +105,11 @@ function CartDrawer({ open, setOpen }) {
                                     className="flex py-6 space-x-4 sm:space-x-16"
                                   >
                                     <div className="h-32 w-28 flex-shrink-0 overflow-hidden rounded-2xl">
-                                      <img
+                                      <LazyLoadImage
                                         src={`https://apis.spaceyatech.com${image}`}
                                         alt={name}
                                         className="h-full w-full object-cover object-center"
+                                        effect="blur"
                                       />
                                     </div>
 
@@ -126,9 +132,10 @@ function CartDrawer({ open, setOpen }) {
                                             handleDeleteSwag(id);
                                           }}
                                         >
-                                          <img
+                                          <LazyLoadImage
                                             src={DeleteIcon}
                                             alt="delete button"
+                                            effect="blur"
                                           />
                                         </button>
                                       </div>
@@ -160,10 +167,11 @@ function CartDrawer({ open, setOpen }) {
                         </p>
                         <div className="flex pb-8 pt-10 space-x-4 sm:space-x-16 sm:px-8">
                           <div className="h-32 w-28 flex-shrink-0 overflow-hidden rounded-2xl">
-                            <img
+                            <LazyLoadImage
                               src={Sample3}
                               alt="Mentorlst Hoodie"
                               className="h-full w-full"
+                              effect="blur"
                             />
                           </div>
                           <div className="flex flex-col flex-1 ">

--- a/src/APP/pages/aboutUs/sections/HeroSection.jsx
+++ b/src/APP/pages/aboutUs/sections/HeroSection.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-
 import { about2, heroImg } from "../../../../assets/images/aboutPage";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function HeroSection() {
   return (
@@ -22,15 +22,16 @@ function HeroSection() {
           vibrant community of innovators of tech, users of tech and tech
           evangelists.
         </p>
-        <img
+        <LazyLoadImage
           src={heroImg}
           alt="space ya tech"
           className="absolute -top-8 md:-top-24 lg:-top-8 xl:-top-28 right-0 md:-right-36 lg:-right-48 xl:-right-48 w-2/6 md:w-auto lg:w-[70%]"
+          effect="blur"
         />
       </div>
       <div className="flex flex-col md:flex-row justify-between items-center md:my-20 min-h-96 px-4 ">
         <div className="my-10">
-          <img src={about2} alt="space ya tech" />
+          <LazyLoadImage src={about2} alt="space ya tech" effect="blur" />
         </div>
         <div className="leading-6 md:w-1/2 text-base space-y-4 md:pl-10">
           <p>

--- a/src/APP/pages/aboutUs/sections/LeadershipSection.jsx
+++ b/src/APP/pages/aboutUs/sections/LeadershipSection.jsx
@@ -6,6 +6,7 @@ import { Caroussel } from "../../../components";
 import { closeIcon } from "../../../../assets/images/icons";
 import { LeadershipData } from "../data";
 import { buildComm } from "../../../../assets/images/aboutPage";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 // env var
 const SERVICE_ID =
@@ -143,10 +144,11 @@ function LeadershipSection() {
                   >
                     <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-md bg-white p-4 md:p-6 text-left align-middle shadow-xl transition-all flex flex-col items-end gap-4">
                       <button type="button" onClick={closeModal}>
-                        <img
+                        <LazyLoadImage
                           src={closeIcon}
                           alt="close"
                           className="object-contain w-4 h-4"
+                          effect="blur"
                         />
                       </button>
                       <form
@@ -222,7 +224,11 @@ function LeadershipSection() {
           </Transition>
         </div>
         <div className="md:w-1/2">
-          <img src={buildComm} alt="Space ya Tech Community" />
+          <LazyLoadImage
+            src={buildComm}
+            alt="Space ya Tech Community"
+            effect="blur"
+          />
         </div>
       </div>
     </section>

--- a/src/APP/pages/aboutUs/sections/PartnerCTA.jsx
+++ b/src/APP/pages/aboutUs/sections/PartnerCTA.jsx
@@ -11,6 +11,7 @@
 //   discord,
 // } from "../../../../assets/images/socials";
 // import Caroussel from "../../../components/Caroussel";
+// import { LazyLoadImage } from "react-lazy-load-image-component";
 
 // const CreativeTeamData = [
 //   {
@@ -72,7 +73,7 @@ function PartnerCTA() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img src={twitter} alt="twitter" className="w-12 h-12" />
+              <LazyLoadImage src={twitter} alt="twitter" className="w-12 h-12" effect="blur" />
             </a>
 
             <a
@@ -80,7 +81,7 @@ function PartnerCTA() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img src={linkedin} alt="linkedin" className="w-12 h-12" />
+              <LazyLoadImage src={linkedin} alt="linkedin" className="w-12 h-12" effect="blur" />
             </a>
 
             <a
@@ -88,7 +89,7 @@ function PartnerCTA() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img src={discord} alt="discord" className="w-12 h-12 p-3" />
+              <LazyLoadImage src={discord} alt="discord" className="w-12 h-12 p-3" effect="blur" />
             </a>
 
             <a
@@ -96,7 +97,7 @@ function PartnerCTA() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img src={instagram} alt="instagram" className="w-12 h-12" />
+              <LazyLoadImage src={instagram} alt="instagram" className="w-12 h-12" effect="blur" />
             </a>
 
             <a
@@ -104,7 +105,7 @@ function PartnerCTA() {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img src={facebook} alt="facebook" className="w-12 h-12" />
+              <LazyLoadImage src={facebook} alt="facebook" className="w-12 h-12" effect="blur" />
             </a>
           </div>
         </div> */}

--- a/src/APP/pages/auth/ForgotPassword.jsx
+++ b/src/APP/pages/auth/ForgotPassword.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import ForgotPasswordImg from "../../../assets/images/auth/forgot-password.svg";
 import EmailIcon from "../../../assets/images/auth/email-icon.svg";
 import MessageIcon from "../../../assets/images/auth/message-icon.svg";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function ForgotPassword() {
   return (
@@ -13,7 +14,12 @@ function ForgotPassword() {
           Forgot Password?
         </h1>
         <h2 className="text-2xl mb-4">Let&apos;s recover your account</h2>
-        <img src={ForgotPasswordImg} alt="Forgot Password" className="m-auto" />
+        <LazyLoadImage
+          src={ForgotPasswordImg}
+          alt="Forgot Password"
+          className="m-auto"
+          effect="blur"
+        />
       </div>
 
       <div className="text-center px-6 py-3 sm:py-12 my-10 max-w-screen-md xl:w-1/3 lg:w-2/3 w-full text-[#080808]">
@@ -25,7 +31,7 @@ function ForgotPassword() {
         </p>
         <form className="space-y-6">
           <div className="flex space-x-8 border rounded-xl border-[#79747E] py-2 px-4">
-            <img src={EmailIcon} alt="Email Icon" />
+            <LazyLoadImage src={EmailIcon} alt="Email Icon" effect="blur" />
             <label className="text-left space-y-2 flex flex-col justify-center">
               <span className="text-[#79747E]">Via Email</span>
               <input
@@ -37,7 +43,7 @@ function ForgotPassword() {
             </label>
           </div>
           <div className="flex space-x-8 border rounded-xl border-[#79747E] py-2 px-4">
-            <img src={MessageIcon} alt="Message Icon" />
+            <LazyLoadImage src={MessageIcon} alt="Message Icon" effect="blur" />
             <label className="text-left space-y-2 flex flex-col justify-center">
               <span className="text-[#79747E]">Via SMS</span>
               <input

--- a/src/APP/pages/auth/LogIn.jsx
+++ b/src/APP/pages/auth/LogIn.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import publicAxios from "../../../api/publicAxios";
 import LoginImg from "../../../assets/images/auth/login.svg";
 import useAuth from "../../../hooks/useAuth";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function LogIn() {
   const { auth, setAuth } = useAuth();
@@ -45,7 +46,12 @@ function LogIn() {
         <h2 className="text-2xl">
           It&apos;s always a pleasure to see you again
         </h2>
-        <img src={LoginImg} alt="Log in" className="m-auto" />
+        <LazyLoadImage
+          src={LoginImg}
+          alt="Log in"
+          className="m-auto"
+          effect="blur"
+        />
       </div>
 
       <div className="text-center px-6 py-3 sm:py-12 my-10 max-w-screen-md xl:w-1/3 lg:w-2/3 w-full text-[#080808]">

--- a/src/APP/pages/auth/ResetPassword.jsx
+++ b/src/APP/pages/auth/ResetPassword.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ResetPasswordImg from "../../../assets/images/auth/reset-password.svg";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function ResetPassword() {
   return (
@@ -11,7 +12,12 @@ function ResetPassword() {
         <h2 className="text-2xl mb-4">
           Let&apos;s create a new password for your account
         </h2>
-        <img src={ResetPasswordImg} alt="Reset Password" className="m-auto" />
+        <LazyLoadImage
+          src={ResetPasswordImg}
+          alt="Reset Password"
+          className="m-auto"
+          effect="blur"
+        />
       </div>
 
       <div className="text-center px-6 py-3 sm:py-12 my-10 max-w-screen-md xl:w-1/3 lg:w-2/3 w-full text-[#080808]">

--- a/src/APP/pages/auth/SignUp.jsx
+++ b/src/APP/pages/auth/SignUp.jsx
@@ -3,6 +3,7 @@ import { Navigate } from "react-router-dom";
 import publicAxios from "../../../api/publicAxios";
 import SignUpImg from "../../../assets/images/auth/signup.svg";
 import useAuth from "../../../hooks/useAuth";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function SignUp() {
   const { auth, setAuth } = useAuth();
@@ -71,7 +72,12 @@ function SignUp() {
           Shop!
         </h1>
         <h2 className="text-2xl">Let&apos;s get you started</h2>
-        <img src={SignUpImg} alt="Sign Up Page" className="m-auto" />
+        <LazyLoadImage
+          src={SignUpImg}
+          alt="Sign Up Page"
+          className="m-auto"
+          effect="blur"
+        />
       </div>
 
       <div className="text-center px-6 py-3 sm:py-12 my-10 max-w-screen-md xl:w-1/3 lg:w-2/3 w-full text-[#080808]">

--- a/src/APP/pages/blog/Blog.jsx
+++ b/src/APP/pages/blog/Blog.jsx
@@ -4,6 +4,7 @@ import useBlogData from "../../../hooks/Queries/blog/useBlogData";
 import { Loader } from "../../components";
 import BlogWrapper from "./sections/BlogWrapper";
 import RelatedBlogs from "./sections/RelatedBlogs";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Blog() {
   const { titleSlug } = useParams();
@@ -35,10 +36,11 @@ function Blog() {
       )}
       {isSuccess && (
         <section className="flex flex-col p-4 md:p-8 lg:p-10">
-          <img
+          <LazyLoadImage
             src={blogData.image}
             alt={blogData.title}
             className="w-full h-60 md:h-72 object-cover rounded-lg mb-4 md:mb-8"
+            effect="blur"
           />
 
           <BlogWrapper blog={blogData} />

--- a/src/APP/pages/blog/sections/BlogWrapper.jsx
+++ b/src/APP/pages/blog/sections/BlogWrapper.jsx
@@ -7,6 +7,8 @@ import BlogStats from "../../blogs/sections/BlogStats";
 
 import "./blogWrapper.css";
 
+import { LazyLoadImage } from "react-lazy-load-image-component";
+
 function BlogWrapper({ blog }) {
   const timeAgo = formatDistanceToNow(new Date(blog?.created_at), {
     addSuffix: true,
@@ -22,10 +24,11 @@ function BlogWrapper({ blog }) {
 
           <div className="flex items-center justify-between">
             <div className="flex gap-2">
-              <img
+              <LazyLoadImage
                 src={logo}
                 alt="icon"
                 className="w-10 h-10 object-cover rounded-full bg-gray-200 flex items-center justify-center p-1"
+                effect="blur"
               />
 
               <div className="flex flex-col text-sm">

--- a/src/APP/pages/blog/sections/Comments.jsx
+++ b/src/APP/pages/blog/sections/Comments.jsx
@@ -4,16 +4,18 @@ import {
   reply,
 } from "../../../../assets/images/blogs-page";
 import CommentInput from "./CommentInput";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const CommentCard = () => {
   return (
     <div className="flex flex-col gap-3 items-start border-b border-[#25253380] pb-3">
       <div className="flex flex-row w-full items-center justify-between gap-4">
         <div className="flex gap-2 md:gap-3">
-          <img
+          <LazyLoadImage
             src={Ellipse30}
             alt="author"
             className="w-8 h-8 rounded-full object-contain"
+            effect="blur"
           />
 
           <div className="flex flex-col md:flex-row md:gap-10 text-[13px] leading-5 md:text-base font-normal text-black">
@@ -23,7 +25,12 @@ const CommentCard = () => {
         </div>
 
         <button className="flex flex-row gap-1">
-          <img src={reply} alt="reply" className="w-4 h-4 object-contain" />
+          <LazyLoadImage
+            src={reply}
+            alt="reply"
+            className="w-4 h-4 object-contain"
+            effect="blur"
+          />
           <span className="text-[13px] text-[#00664E] capitalize">Reply</span>
         </button>
       </div>
@@ -35,7 +42,12 @@ const CommentCard = () => {
         faucibus facilisis tortor enim nulla turpis.
       </p>
       <button className="flex flex-row gap-1">
-        <img src={chatText} alt="chatText" className="w-4 h-4 object-contain" />
+        <LazyLoadImage
+          src={chatText}
+          alt="chatText"
+          className="w-4 h-4 object-contain"
+          effect="blur"
+        />
         <span className="text-xs font-normal text-[#00664E]">35</span>
       </button>
     </div>

--- a/src/APP/pages/blog/sections/RelatedBlogCard.jsx
+++ b/src/APP/pages/blog/sections/RelatedBlogCard.jsx
@@ -6,6 +6,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { arrowRight } from "../../../../assets/images/blogs-page";
 import logo from "../../../../assets/images/sytLogo.png";
 import { BlogStats } from "../../blogs/sections";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function RelatedBlogCard({ blog }) {
   const navigate = useNavigate();
@@ -21,10 +22,11 @@ function RelatedBlogCard({ blog }) {
       to={`/blogs/${blog.title_slug}`}
       className="flex flex-col items-start w-full mb-5"
     >
-      <img
+      <LazyLoadImage
         src={`https://apis.spaceyatech.com/${blog.image}`}
         alt={blog.title}
         className="w-full h-60 object-cover rounded-lg"
+        effect="blur"
       />
 
       <div className="py-[6px] flex flex-col gap-[10px] w-full mt-2">
@@ -40,10 +42,11 @@ function RelatedBlogCard({ blog }) {
 
         <div className="flex flex-row items-start justify-between">
           <div className="flex gap-[10px]">
-            <img
+            <LazyLoadImage
               src={logo}
               alt="icon"
               className="w-10 h-10 object-cover bg-gray-200 flex items-center justify-center p-1 rounded-full"
+              effect="blur"
             />
 
             <div className="flex flex-col gap-1 text-sm">
@@ -64,7 +67,12 @@ function RelatedBlogCard({ blog }) {
             <span className="uppercase text-primary text-sm font-medium m-0">
               read more
             </span>
-            <img src={arrowRight} alt="arrow-right" className="w-5 h-5" />
+            <LazyLoadImage
+              src={arrowRight}
+              alt="arrow-right"
+              className="w-5 h-5"
+              effect="blur"
+            />
           </button>
         </div>
       </div>

--- a/src/APP/pages/blog2/sections/Advert.jsx
+++ b/src/APP/pages/blog2/sections/Advert.jsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { advert } from "../../../../assets/images/blogs-page";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Advert() {
   return (
     <div className="hidden md:flex h-32 w-full">
-      <img src={advert} alt="advert" className="h-full w-full" />
+      <LazyLoadImage
+        src={advert}
+        alt="advert"
+        className="h-full w-full"
+        effect="blur"
+      />
     </div>
   );
 }

--- a/src/APP/pages/blog2/sections/BlogBody.jsx
+++ b/src/APP/pages/blog2/sections/BlogBody.jsx
@@ -7,6 +7,7 @@ import RelatedBlogs from "./RelatedBlogs";
 import NextRead from "./NextRead";
 
 import "./blogBody.css";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function BlogBody({ id, categoryId, blogBody }) {
   return (
@@ -31,10 +32,11 @@ function BlogBody({ id, categoryId, blogBody }) {
       <div className="w-full md:w-[30%] hidden md:flex flex-col pt-20 gap-10 md:gap-64">
         <RelatedBlogs blogId={id} categoryId={categoryId} />
 
-        <img
+        <LazyLoadImage
           src={glovo}
           alt="glovo"
           className="object-cover w-full aspect-auto"
+          effect="blur"
         />
       </div>
     </div>

--- a/src/APP/pages/blog2/sections/BlogHeader.jsx
+++ b/src/APP/pages/blog2/sections/BlogHeader.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import logo from "../../../../assets/images/sytLogo.png";
 import BlogStats from "../../blogs/sections/BlogStats";
 import ShareBlog from "./ShareBlog";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function BlogHeader({
   id,
@@ -32,10 +33,11 @@ function BlogHeader({
         </p>
 
         <div className="flex items-center gap-2 mt-5 md:my-3">
-          <img
+          <LazyLoadImage
             src={logo}
             alt={author}
             className="w-10 h-10 object-cover rounded-full flex items-center justify-center"
+            effect="blur"
           />
 
           <span className="text-sm md:text-base font-medium text-[#323433] capitalize">
@@ -47,10 +49,11 @@ function BlogHeader({
       </div>
 
       <div className="flex flex-col gap-4 py-5">
-        <img
+        <LazyLoadImage
           src={image}
           alt={title}
           className="object-contain overflow-hidden w-full lg:rounded-xl px-4 md:px-0"
+          effect="blur"
         />
 
         <div className="flex flex-row items-center justify-between px-3 ">

--- a/src/APP/pages/blog2/sections/BlogUMightLike.jsx
+++ b/src/APP/pages/blog2/sections/BlogUMightLike.jsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 
 import logo from "../../../../assets/images/sytLogo.png";
 import BlogStats from "../../blogs/sections/BlogStats";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function BlogUMightLike({ blog, block }) {
   const timeAgo = formatDistanceToNow(new Date(blog.created_at), {
@@ -17,10 +18,11 @@ function BlogUMightLike({ blog, block }) {
         block ? "block" : "hidden"
       } flex flex-col min-w-full snap-center`}
     >
-      <img
+      <LazyLoadImage
         src={blog.image}
         alt={blog.title}
         className="h-48 w-full object-cover aspect-video rounded-lg"
+        effect="blur"
       />
 
       <div className="h-1/2 flex flex-col gap-2 py-2">
@@ -37,10 +39,11 @@ function BlogUMightLike({ blog, block }) {
         </p>
 
         <div className="flex items-center gap-3 mt-5 md:my-3">
-          <img
+          <LazyLoadImage
             src={logo}
             alt="ellipse"
             className="w-10 h-10 object-cover rounded-full flex items-center justify-center"
+            effect="blur"
           />
 
           <div className="flex flex-col">

--- a/src/APP/pages/blog2/sections/RelatedBlogCard.jsx
+++ b/src/APP/pages/blog2/sections/RelatedBlogCard.jsx
@@ -2,6 +2,7 @@
 import { formatDistanceToNow } from "date-fns";
 import React from "react";
 import { Link } from "react-router-dom";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function RelatedBlogCard({ blog }) {
   const timeAgo = formatDistanceToNow(new Date(blog.created_at), {
@@ -12,10 +13,11 @@ function RelatedBlogCard({ blog }) {
       className="flex flex-row items-center gap-2 w-64"
       to={`/blogs2/${blog.title_slug}`}
     >
-      <img
+      <LazyLoadImage
         src={`https://apis.spaceyatech.com${blog.image}`}
         alt={blog.title}
         className="object-cover h-20 w-20"
+        effect="blur"
       />
 
       <div className="flex flex-col">

--- a/src/APP/pages/blogs/sections/Banner.jsx
+++ b/src/APP/pages/blogs/sections/Banner.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 
 import { search } from "../../../../assets/images/blogs-page";
 import { SearchBlogContext } from "../../../../context/searchBlog";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Banner() {
   const { searchText, setSearchText } = useContext(SearchBlogContext);
@@ -24,7 +25,12 @@ function Banner() {
             className="w-1/10 p-2"
             onClick={(e) => e.preventDefault()}
           >
-            <img src={search} alt="search" className="w-6 h-6" />
+            <LazyLoadImage
+              src={search}
+              alt="search"
+              className="w-6 h-6"
+              effect="blur"
+            />
           </button>
         </form>
       </div>

--- a/src/APP/pages/blogs/sections/BlogCard.jsx
+++ b/src/APP/pages/blogs/sections/BlogCard.jsx
@@ -6,6 +6,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { arrowRight } from "../../../../assets/images/blogs-page";
 import logo from "../../../../assets/images/sytLogo.png";
 import BlogStats from "./BlogStats";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function BlogCard({ blog }) {
   const navigate = useNavigate();
@@ -21,10 +22,11 @@ function BlogCard({ blog }) {
       to={`/blogs/${blog.title_slug}`}
       className="flex flex-col items-start w-full mb-5"
     >
-      <img
+      <LazyLoadImage
         src={blog.image}
         alt={blog.title}
         className="w-full h-60 object-cover rounded-lg"
+        effect="blur"
       />
 
       <div className="py-[6px] flex flex-col gap-[10px] w-full mt-2">
@@ -40,10 +42,11 @@ function BlogCard({ blog }) {
 
         <div className="flex flex-row items-start justify-between">
           <div className="flex gap-[10px]">
-            <img
+            <LazyLoadImage
               src={logo}
               alt="icon"
               className="w-10 h-10 object-cover bg-gray-200 flex items-center justify-center p-1 rounded-full"
+              effect="blur"
             />
 
             <div className="flex flex-col gap-1 text-sm">
@@ -64,7 +67,12 @@ function BlogCard({ blog }) {
             <span className="uppercase text-primary text-sm font-medium m-0">
               read more
             </span>
-            <img src={arrowRight} alt="arrow-right" className="w-5 h-5" />
+            <LazyLoadImage
+              src={arrowRight}
+              alt="arrow-right"
+              className="w-5 h-5"
+              effect="blur"
+            />
           </button>
         </div>
       </div>

--- a/src/APP/pages/blogs/sections/BlogStats.jsx
+++ b/src/APP/pages/blogs/sections/BlogStats.jsx
@@ -1,55 +1,63 @@
 import { useEffect, useState } from "react";
 import { thumbsUp } from "../../../../assets/images/blogs-page";
 import usePostLikeBlog from "../../../../hooks/Queries/blog/usePostLikeBlog";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const BlogStats = ({ blogId, likes }) => {
-  const [ updatedLikes, setUpdatedLikes ] = useState(likes);
+  const [updatedLikes, setUpdatedLikes] = useState(likes);
 
   const {
     setBlogIDLikes: likeBlog,
     error: errorLikeBlog,
     clearError: clearErrorLikeBlog,
     status: statusLikeBlog,
-    clearStatus: clearStatusLikeBlog
+    clearStatus: clearStatusLikeBlog,
   } = usePostLikeBlog();
 
   const addLikeToBlog = (blogId) => {
-    statusLikeBlog === 'error' && clearErrorLikeBlog();
+    statusLikeBlog === "error" && clearErrorLikeBlog();
     errorLikeBlog && clearErrorLikeBlog();
-    
-    const blogDetails = {
-      'id': blogId
-    }
 
-    likeBlog({...blogDetails})
-  }
+    const blogDetails = {
+      id: blogId,
+    };
+
+    likeBlog({ ...blogDetails });
+  };
 
   useEffect(() => {
-    if (statusLikeBlog === 'success') {
+    if (statusLikeBlog === "success") {
       const newLikes = likes + 1;
       setUpdatedLikes(newLikes);
     }
     clearStatusLikeBlog();
     clearErrorLikeBlog();
-  }, [likes, statusLikeBlog])
+  }, [likes, statusLikeBlog]);
 
   return (
     <div className="flex flex-row items-center gap-2">
       {/* <div className="flex flex-row items-center gap-1">
-        <img src={eye} alt="eye" className="w-5 h-5 object-cover" />
+        <LazyLoadImage src={eye} alt="eye" className="w-5 h-5 object-cover" effect="blur" />
         <span className="text-base text-[#00664E]">240</span>
       </div> */}
 
       <div className="flex flex-row items-center gap-1">
-        <img src={thumbsUp} alt="eye" className="w-5 h-5 object-cover cursor-pointer"
-            onClick={() => {
-              blogId ? addLikeToBlog(blogId) : ''
-            }} />
-        <span className="text-base text-[#00664E] leading-5 m-0">{updatedLikes}</span>
+        <LazyLoadImage
+          src={thumbsUp}
+          alt="eye"
+          className="w-5 h-5 object-cover cursor-pointer"
+          effect="blur"
+          onClick={() => {
+            blogId ? addLikeToBlog(blogId) : "";
+          }}
+        />
+        <span className="text-base text-[#00664E] leading-5 m-0">
+          {updatedLikes}
+        </span>
       </div>
 
       {/* <div className="flex flex-row items-center gap-1">
-        <img src={chatText} alt="eye" className="w-5 h-5 object-cover" />
+        <LazyLoadImage src={chatText} alt="eye" className="w-5 h-5 object-cover" effect="blur" />
         <span className="text-base text-[#00664E]">35</span>
       </div> */}
     </div>

--- a/src/APP/pages/chapter/sections/OrganizersSection.jsx
+++ b/src/APP/pages/chapter/sections/OrganizersSection.jsx
@@ -13,6 +13,7 @@ import DetailsContainer from "./DetailsContainer";
 //   paragraph:
 //     "The SpaceYaTech Nairobi Chapter is led by a capable team of developers and designers from Kenya. ",
 // };
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function ImpactSection({ organizers, city, country }) {
   // content-between md:px-20
@@ -29,10 +30,11 @@ function ImpactSection({ organizers, city, country }) {
               className="relative w-full h-72 rounded-lg overflow-auto mr-6 md:mr-0"
               key={id}
             >
-              <img
+              <LazyLoadImage
                 className="absolute inset-0 w-full h-full object-cover"
                 src={image}
                 alt="Image"
+                effect="blur"
               />
               <div className="absolute inset-0" />
               <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black to-transparent opacity-50 h-1/2" />

--- a/src/APP/pages/community/sections/chaptersSection/ChapterCard.jsx
+++ b/src/APP/pages/community/sections/chaptersSection/ChapterCard.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function ChapterCard({ id, country, city, name, members, banner }) {
   return (
     <div className="relative h-80 border-2 rounded-lg border-white overflow-hidden">
-      <img src={banner} alt={name} className="w-full h-full object-cover" />
+      <LazyLoadImage src={banner} alt={name} className="w-full h-full object-cover" effect="blur" />
       <div className="absolute bottom-0 left-0 right-0 bg-black opacity-60 h-full" />
 
       <div className="absolute bottom-14 inset-x-0 text-white flex flex-col items-center">

--- a/src/APP/pages/community/sections/gallerySection/GallerySection.jsx
+++ b/src/APP/pages/community/sections/gallerySection/GallerySection.jsx
@@ -12,6 +12,7 @@ import {
   galleryimage8,
   galleryimage9,
 } from "../../../../../assets/images/community";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 // const photos = [{ image:galleryimage1}, { image:galleryimage2 }, { image: galleryimage3 }, { image: galleryimage4}, { image: galleryimage5 }, { image: galleryimage6}, { image: galleryimage7}, { image: galleryimage8}]
 function GallerySection() {
@@ -22,63 +23,71 @@ function GallerySection() {
         <div className="-m-1 flex  md:-m-2">
           <div className="flex w-3/8 flex-wrap">
             <div className="w-1/3">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage1}
+                effect="blur"
               />
             </div>
             <div className="w-1/3">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage7}
+                effect="blur"
               />
             </div>
             <div className="w-1/3">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage9}
+                effect="blur"
               />
             </div>
             <div className="w-full">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage2}
+                effect="blur"
               />
             </div>
           </div>
           <div className="flex w-3/8 flex-wrap">
             <div className="w-full">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage4}
+                effect="blur"
               />
             </div>
             <div className="w-1/2">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage6}
+                effect="blur"
               />
             </div>
             <div className="w-1/2">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage5}
+                effect="blur"
               />
             </div>
           </div>
           <div className="flex w-1/4 flex-wrap">
             <div className="w-full">
-              <img
+              <LazyLoadImage
                 alt="gallery"
                 className="block h-full w-full  object-cover object-center"
                 src={galleryimage3}
+                effect="blur"
               />
             </div>
           </div>

--- a/src/APP/pages/community/sections/partnerSection/PartnerCard.jsx
+++ b/src/APP/pages/community/sections/partnerSection/PartnerCard.jsx
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function PartnerCard({ image, backgroundColor, link }) {
   return (
@@ -6,7 +7,7 @@ function PartnerCard({ image, backgroundColor, link }) {
       className="flex flex-col items-center p-8 justify-between h-80 border-2 rounded-2xl"
       style={{ backgroundColor: `${backgroundColor}` }}
     >
-      <img src={image} />
+      <LazyLoadImage src={image} effect="blur" />
       <a
         href={link}
         target="_blank"

--- a/src/APP/pages/donate/DonatePage.jsx
+++ b/src/APP/pages/donate/DonatePage.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import RangeInput from "./RangeInput";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 // this is the donate page with products and donation progress bar
 function DonatePage() {
@@ -79,10 +80,11 @@ function DonatePage() {
         {projects?.map((project) => (
           <div key={project.id} className="shadow-lg rounded-md text-sm">
             <div className="h-[12rem]">
-              <img
+              <LazyLoadImage
                 src="https://images.unsplash.com/photo-1569098644584-210bcd375b59?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80"
                 alt="unsplash-img"
                 className="object-cover w-full h-full rounded-t-md"
+                effect="blur"
               />
             </div>
             <div className="p-2">
@@ -98,7 +100,11 @@ function DonatePage() {
               </p>
               <RangeInput />
               <div className="flex items-center justify-between my-2">
-                <img src="/donate.png" alt="donate-img" />
+                <LazyLoadImage
+                  src="/donate.png"
+                  alt="donate-img"
+                  effect="blur"
+                />
                 <Link
                   to={`/donate/${project?.id}`}
                   className="flex items-center gap-2"

--- a/src/APP/pages/donate/pages/SingleProductDonatePage.jsx
+++ b/src/APP/pages/donate/pages/SingleProductDonatePage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 //this page will redirect from the donate page on click of a single project
 function SingleProductDonatePage() {
@@ -16,34 +17,39 @@ function SingleProductDonatePage() {
       <div className="grid grid-cols-1 md:grid-cols-5 gap-10">
         <div className="md:col-span-3 space-y-4">
           <div className="h-[20rem]">
-            <img
+            <LazyLoadImage
               src="https://images.unsplash.com/photo-1569098644584-210bcd375b59?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80"
               alt="img"
               className="object-cover w-full h-full rounded-2xl"
+              effect="blur"
             />
           </div>
           <div className="flex items-center justify-between">
             <div className="flex items-center justify-center gap-2">
               <div class="flex -space-x-4">
-                <img
+                <LazyLoadImage
                   class="w-10 h-10 border-2 border-white rounded-full dark:border-gray-800"
                   src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
                   alt="img-1"
+                  effect="blur"
                 />
-                <img
+                <LazyLoadImage
                   class="w-10 h-10 border-2 border-white rounded-full dark:border-gray-800"
                   src="https://flowbite.com/docs/images/people/profile-picture-2.jpg"
                   alt="img-2"
+                  effect="blur"
                 />
-                <img
+                <LazyLoadImage
                   class="w-10 h-10 border-2 border-white rounded-full dark:border-gray-800"
                   src="https://flowbite.com/docs/images/people/profile-picture-3.jpg"
                   alt="img-3"
+                  effect="blur"
                 />
-                <img
+                <LazyLoadImage
                   class="w-10 h-10 border-2 border-white rounded-full dark:border-gray-800"
                   src="https://flowbite.com/docs/images/people/profile-picture-4.jpg"
                   alt="img-4"
+                  effect="blur"
                 />
               </div>
               <p className="inline-block text-xs">100 donors</p>
@@ -51,15 +57,17 @@ function SingleProductDonatePage() {
             <div className="flex items-center justify-center gap-2">
               <p className="hidden md:inline-block text-xs">Organizers</p>
               <div className="flex items-center justify-center">
-                <img
+                <LazyLoadImage
                   src="/src/assets/images/sytLogo.png"
                   alt="syt logo"
                   className="w-auto h-6"
+                  effect="blur"
                 />
-                <img
+                <LazyLoadImage
                   src="/src/assets/images/kamilimu.png"
                   alt="kamilimu logo"
                   className="w-auto h-6"
+                  effect="blur"
                 />
               </div>
             </div>

--- a/src/APP/pages/errorPages/Error400.jsx
+++ b/src/APP/pages/errorPages/Error400.jsx
@@ -1,14 +1,16 @@
 import React from "react";
 
 import { error400 } from "../../../assets/images/errorPages";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Error400() {
   return (
     <section className="max-w-[1440px] mx-auto flex flex-col items-center gap-0 pb-10 md:pb-8">
-      <img
+      <LazyLoadImage
         src={error400}
         alt="Error400"
         className="p-4 mt-5 md:my-10 sm:px-12 sm:my-0 h-[400px] md:h-[540px] object-contain w-full sm:w-fit"
+        effect="blur"
       />
 
       <div className="flex flex-col items-center justify-center gap-2 sm:gap-3 text-center max-w-lg">

--- a/src/APP/pages/errorPages/Error403.jsx
+++ b/src/APP/pages/errorPages/Error403.jsx
@@ -2,13 +2,16 @@ import React from "react";
 
 import { error403 } from "../../../assets/images/errorPages";
 
+import { LazyLoadImage } from "react-lazy-load-image-component";
+
 function Error403() {
   return (
     <section className="max-w-[1440px] mx-auto flex flex-col items-center gap-6 md:gap-0 pb-10 md:pb-8">
-      <img
+      <LazyLoadImage
         src={error403}
         alt="Error403"
         className="px-4 mt-5 md:my-10 sm:px-12 sm:my-0 h-[400px] md:h-[540px] w-full sm:w-fit"
+        effect="blur"
       />
 
       <div className="flex flex-col items-center justify-center gap-2 sm:gap-3 text-center max-w-lg">

--- a/src/APP/pages/errorPages/Error404.jsx
+++ b/src/APP/pages/errorPages/Error404.jsx
@@ -2,16 +2,18 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import { error404 } from "../../../assets/images/errorPages";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Error404() {
   const navigate = useNavigate();
 
   return (
     <section className="max-w-[1440px] mx-auto flex flex-col items-center gap-0 pb-10 md:pb-8">
-      <img
+      <LazyLoadImage
         src={error404}
         alt="Error404"
         className="p-4 mt-5 md:my-10 sm:px-12 sm:my-0 h-[400px] md:h-[540px] object-contain w-full sm:w-fit"
+        effect="blur"
       />
 
       <div className="flex flex-col items-center justify-center gap-2 sm:gap-3 text-center max-w-lg">

--- a/src/APP/pages/errorPages/Error500.jsx
+++ b/src/APP/pages/errorPages/Error500.jsx
@@ -1,21 +1,24 @@
 import React from "react";
 import { bgError500, error500svg } from "../../../assets/images/errorPages";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Error500() {
   return (
     <section className="max-w-[1440px] mx-auto flex-center flex-col gap-3 pb-8">
       <div className="relative flex-center flex-col pt-8 w-full">
-        <img
+        <LazyLoadImage
           src={bgError500}
           alt="bgError500"
           className="object-cover w-full h-full"
+          effect="blur"
         />
 
         <div className="flex flex-row items-end absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full">
-          <img
+          <LazyLoadImage
             src={error500svg}
             alt="error-500"
             className="lg:flex hidden object-contain w-full h-[720px]"
+            effect="blur"
           />
 
           <div className="hidden lg:flex justify-center text-left flex-col gap-3 p-4 mb-16">
@@ -43,10 +46,11 @@ function Error500() {
           </div>
         </div>
 
-        <img
+        <LazyLoadImage
           src={error500svg}
           alt="error-500"
           className="flex lg:hidden object-contain absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-3/4"
+          effect="blur"
         />
       </div>
 

--- a/src/APP/pages/events/sections/eventsSection/Events.jsx
+++ b/src/APP/pages/events/sections/eventsSection/Events.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import formatEventDates from "../../../../../utilities/formatEventDate";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function Events({ events, isVertical }) {
   const verticalContainer =
@@ -53,10 +54,11 @@ function Events({ events, isVertical }) {
                   }}
                 >
                   <Link to={`/events/${id}`} className="cursor-pointer">
-                    <img
+                    <LazyLoadImage
                       className="rounded-t-lg w-full h-56 object-contain"
                       src={poster}
                       alt={name}
+                      effect="blur"
                     />
 
                     <div className="p-5 text-[#323433] w-full">

--- a/src/APP/pages/gallery/sections/ImageCardss.jsx
+++ b/src/APP/pages/gallery/sections/ImageCardss.jsx
@@ -1,14 +1,16 @@
 // import React from "react";
+// import { LazyLoadImage } from "react-lazy-load-image-component";
 
 // function ImageCard({ photo }) {
 //   const { width, src, alt, date, event, height } = photo;
 //   return (
 //     <div className={`relative border w-[${width}px]`}>
-//       <img
+//       <LazyLoadImage
 //         src={src}
 //         alt={alt}
 //         className="aspect-video object-cover"
 //         loading="lazy"
+//         effect="blur"
 //       />
 
 //       <div className="absolute top-0 right-0 w-full h-full flex opacity-0 transition-all duration-500 ease-linear hover:opacity-100">

--- a/src/APP/pages/landingPage/sections/HeroSection.jsx
+++ b/src/APP/pages/landingPage/sections/HeroSection.jsx
@@ -4,6 +4,7 @@ import react_ke from "../../../../assets/images/reactke.png";
 import kamilimu from "../../../../assets/images/kamilimu.png";
 import cytonn from "../../../../assets/images/cytonn.png";
 import osca from "../../../../assets/images/osca.png";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function HeroSection() {
   return (
@@ -62,52 +63,58 @@ function HeroSection() {
 
               {/* logo 2  */}
               <div className="flex justify-center items-center">
-                <img
+                <LazyLoadImage
                   className="object-cover object-center"
                   alt="gdg"
                   src={gdg_image}
+                  effect="blur"
                 />
               </div>
               {/* logo 3  */}
               <div className="flex justify-center items-center">
-                <img
+                <LazyLoadImage
                   className="object-cover object-center"
                   alt="react-ke"
                   src={react_ke}
+                  effect="blur"
                 />
               </div>
               {/* logo 4  */}
               <div className="flex justify-center items-center">
-                <img
+                <LazyLoadImage
                   className="object-cover object-center"
                   alt="kamilimu"
                   src={kamilimu}
+                  effect="blur"
                 />
               </div>
               {/* logo 5  */}
               <div className="flex justify-center items-center">
-                <img
+                <LazyLoadImage
                   className="object-cover object-center"
                   alt="cytonn"
                   src={cytonn}
+                  effect="blur"
                 />
               </div>
               {/* logo 6 */}
               <div className="flex justify-center items-center">
-                <img
+                <LazyLoadImage
                   className="object-cover object-center"
                   alt="osca"
                   src={osca}
+                  effect="blur"
                 />
               </div>
             </div>
           </div>
         </div>
         <div className="hidden md:block lg:max-w-lg lg:w-full md:w-1/2 w-5/6">
-          <img
+          <LazyLoadImage
             className="object-cover object-center rounded"
             alt="hero"
             src={hero_image}
+            effect="blur"
           />
         </div>
       </div>

--- a/src/APP/pages/landingPage/sections/HeroSection2.jsx
+++ b/src/APP/pages/landingPage/sections/HeroSection2.jsx
@@ -5,6 +5,7 @@ import kamilimu from "../../../../assets/images/kamilimu.png";
 import cytonn from "../../../../assets/images/cytonn.png";
 import osca from "../../../../assets/images/osca.png";
 import spheron from "../../../../assets/images/spheron.svg";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const partners = [spheron, gdg_image, react_ke, kamilimu, cytonn, osca];
 
@@ -31,10 +32,11 @@ function HeroSection2() {
 
         {/* image */}
         <div className="w-full md:w-2/5 bg-white">
-          <img
+          <LazyLoadImage
             src={hero_image}
             alt="hero image"
             className="px-10 md:p-0 object-contain object-center md:object-right max-h-[532px] w-full"
+            effect="blur"
           />
         </div>
       </div>
@@ -48,11 +50,12 @@ function HeroSection2() {
         </h4>
         <div className="mx-auto overflow-x-scroll md:max-w-4/5 flex items-center justify-between gap-4 md:gap-16">
           {partners.map((partner) => (
-            <img
+            <LazyLoadImage
               src={partner}
               alt="partner"
               className="h-[50px] object-contain"
               key={partner}
+              effect="blur"
             />
           ))}
         </div>

--- a/src/APP/pages/landingPage/sections/HeroSection3.jsx
+++ b/src/APP/pages/landingPage/sections/HeroSection3.jsx
@@ -4,6 +4,7 @@ import Marquee from "react-fast-marquee";
 
 import { partners } from "../data";
 import { bannerImg } from "../../../../assets/images/hero-section";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function HeroSection3() {
   return (
@@ -32,10 +33,11 @@ function HeroSection3() {
 
         {/* hero img */}
         <div className="flex-1">
-          <img
+          <LazyLoadImage
             src={bannerImg}
             alt="banner"
             className="w-full h-full object-cover"
+            effect="blur"
           />
         </div>
       </div>
@@ -59,10 +61,11 @@ function HeroSection3() {
         >
           {partners.map(({ id, img, name, link }) => (
             <a href={link} target="_blank" rel="noopener noreferrer" key={id}>
-              <img
+              <LazyLoadImage
                 src={img}
                 className="object-cover max-w-none px-7"
                 alt={name}
+                effect="blur"
               />
             </a>
           ))}

--- a/src/APP/pages/landingPage/sections/Services.jsx
+++ b/src/APP/pages/landingPage/sections/Services.jsx
@@ -4,13 +4,14 @@ import React from "react";
 
 import { services } from "../data";
 import { serviceImg } from "../../../../assets/images/services-section";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function SytServices({ service }) {
   const { img, title, description, link } = service;
   return (
     <div className="p-4 flex flex-col md:flex-row">
       <div className="inline-flex items-center justify-center mb-4 flex-shrink-0">
-        <img src={img} alt={title} />
+        <LazyLoadImage src={img} alt={title} effect="blur" />
       </div>
       <div className="flex-grow pl-6">
         <h2 className="text-[#F7F7F7] text-2xl title-font font-medium mb-2">
@@ -47,10 +48,11 @@ function Services() {
   return (
     <section className="text-gray-600 body-font flex items-center bg-[#F7F7F7] mx-auto justify-center">
       <div className="flex-half w-1/2 hidden md:flex justify-end">
-        <img
+        <LazyLoadImage
           className="object-cover object-center rounded"
           alt="services"
           src={serviceImg}
+          effect="blur"
         />
       </div>
 

--- a/src/APP/pages/landingPage/sections/TestimonialSection.jsx
+++ b/src/APP/pages/landingPage/sections/TestimonialSection.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Marquee from "react-fast-marquee";
 
 import { testimonialData } from "../data";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function TestimonialSection() {
   return (
@@ -45,10 +46,11 @@ function TestimonialSection() {
                 </p>
               </blockquote>
               <figcaption className=" flex items-center pl-4">
-                <img
+                <LazyLoadImage
                   className="rounded-full w-20 h-20"
                   src={testimonial.img}
-                  alt=""
+                  alt="testimonial"
+                  effect="blur"
                 />
                 <div className="text-left pl-8">
                   <p className="font-medium">{testimonial.user}</p>

--- a/src/APP/pages/products2/sections/DeveloperCard.jsx
+++ b/src/APP/pages/products2/sections/DeveloperCard.jsx
@@ -1,13 +1,15 @@
 import React from "react";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const DeveloperCard = ({ name, title, headshot, portfolio }) => {
   return (
     <div className="relative h-[216px]">
       {/* headshot */}
-      <img
+      <LazyLoadImage
         src={headshot}
         alt={name}
         className="h-[120px] w-[120px] rounded-xl object-cover z-10 absolute top-0 left-1/2 transform -translate-x-1/2 shadow-md md:shadow-transparent"
+        effect="blur"
       />
 
       {/* Details */}

--- a/src/APP/pages/products2/sections/ProductsCard.jsx
+++ b/src/APP/pages/products2/sections/ProductsCard.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { upleft } from "../../../../assets/images/icons";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const ProductsCard = ({ name, desc, img, link, index }) => {
   return (
@@ -25,13 +26,23 @@ const ProductsCard = ({ name, desc, img, link, index }) => {
           <span className="text-base font-medium text-white capitalize">
             View product
           </span>
-          <img src={upleft} alt="view btn" className="w-6 h-6 object-contain" />
+          <LazyLoadImage
+            src={upleft}
+            alt="view btn"
+            className="w-6 h-6 object-contain"
+            effect="blur"
+          />
         </a>
       </div>
 
       {/* pic */}
       <div className="flex-1 min-h-full pb-14">
-        <img src={img} alt={name} className="w-full h-full object-cover" />
+        <LazyLoadImage
+          src={img}
+          alt={name}
+          className="w-full h-full object-cover"
+          effect="blur"
+        />
       </div>
 
       {/* view btn */}
@@ -44,7 +55,12 @@ const ProductsCard = ({ name, desc, img, link, index }) => {
         <span className="text-base font-medium text-white capitalize">
           View product
         </span>
-        <img src={upleft} alt="view btn" className="w-6 h-6 object-contain" />
+        <LazyLoadImage
+          src={upleft}
+          alt="view btn"
+          className="w-6 h-6 object-contain"
+          effect="blur"
+        />
       </a>
     </div>
   );

--- a/src/APP/pages/products2/sections/StackCategory.jsx
+++ b/src/APP/pages/products2/sections/StackCategory.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 const StackCategory = ({ category, stack }) => {
   return (
@@ -8,11 +9,12 @@ const StackCategory = ({ category, stack }) => {
       </h3>
       <div className="flex flex-row items-center gap-6 md:gap-4 px-3 flex-wrap justify-center">
         {stack.map(({ url, alt }) => (
-          <img
+          <LazyLoadImage
             key={alt}
             src={url}
             alt={alt}
             className="h-16 md:h-20 w-16 md:w-20 object-contain"
+            effect="blur"
           />
         ))}
       </div>

--- a/src/APP/pages/products2/sections/Teams.jsx
+++ b/src/APP/pages/products2/sections/Teams.jsx
@@ -6,6 +6,7 @@ import { upleftGreen } from "../../../../assets/images/icons";
 import useStackData from "../../../../hooks/Queries/stack/useStackData";
 import { Loader } from "../../../components";
 import DeveloperCard from "./DeveloperCard";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(" ");
@@ -33,10 +34,11 @@ function Teams() {
           <span className="text-base md:text-[32px] md:leading-normal text-primary font-medium">
             Join us
           </span>
-          <img
+          <LazyLoadImage
             src={upleftGreen}
             alt="upleft"
             className="h-6 w-6 md:h-10 md:w-10 object-contain"
+            effect="blur"
           />
         </Link>
       </div>

--- a/src/APP/pages/resources2/sections/HeroSection.jsx
+++ b/src/APP/pages/resources2/sections/HeroSection.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { earthMoon } from "../../../../assets/images/resources-page";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function HeroSection() {
   return (
@@ -20,10 +21,11 @@ function HeroSection() {
         </p>
       </div>
 
-      <img
+      <LazyLoadImage
         src={earthMoon}
         alt="earth & moon"
         className="absolute md:right-12 right-8 -top-16 md:-top-32 lg:-top-40 object-contain w-32 md:w-96 lg:w-fit md:z-10"
+        effect="blur"
       />
     </div>
   );

--- a/src/APP/pages/resources2/sections/ResourceCard.jsx
+++ b/src/APP/pages/resources2/sections/ResourceCard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { arrow, arrowRight } from "../../../../assets/images/resources-page";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function ResourceCard({
   type,
@@ -39,19 +40,25 @@ function ResourceCard({
       >
         {/* img cover */}
         <div className="h-[180px]">
-          <img src={image} alt={title} className="object-cover h-full w-full" />
+          <LazyLoadImage
+            src={image}
+            alt={title}
+            className="object-cover h-full w-full"
+            effect="blur"
+          />
         </div>
 
         {/* desc */}
         <div className="bg-white p-2 flex flex-col gap-[10px] border shadow-md rounded-b-xl">
           <div className="flex justify-between items-center">
             <h5 className="text-base font-normal">{type}</h5>
-            <img
+            <LazyLoadImage
               src={arrow}
               alt="arrow"
               className={`w-6 h-6 object-contain transform transition-all ease-in duration-500 cursor-pointer ${
                 hovered && "rotate-180"
               }`}
+              effect="blur"
             />
           </div>
 

--- a/src/APP/pages/resources2/sections/ResourcesSection.jsx
+++ b/src/APP/pages/resources2/sections/ResourcesSection.jsx
@@ -6,6 +6,8 @@ import { resourcesData } from "./data";
 import { search } from "../../../../assets/images/resources-page";
 import ResourceCard from "./ResourceCard";
 
+import { LazyLoadImage } from "react-lazy-load-image-component";
+
 function classNames(...classes) {
   return classes.filter(Boolean).join(" ");
 }
@@ -24,7 +26,12 @@ function ResourcesSection() {
             value={searchText}
             onChange={(e) => setSearchText(e.target.value)}
           />
-          <img src={search} alt="search" className="p-2 cursor-pointer" />
+          <LazyLoadImage
+            src={search}
+            alt="search"
+            className="p-2 cursor-pointer"
+            effect="blur"
+          />
         </div>
       </div>
 

--- a/src/APP/pages/shop/OrderSummaryPage.jsx
+++ b/src/APP/pages/shop/OrderSummaryPage.jsx
@@ -9,6 +9,7 @@ import useProductsInCart from "../../../hooks/Queries/shop/useCartProducts";
 import { useOrderSummary } from "../../../hooks/Queries/shop/useOrdersList";
 import Counter from "../../components/shop/Counter";
 import ItemHeader from "./sections/ItemHeader";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 // const products = [
 //   {
@@ -217,10 +218,11 @@ function Checkout() {
                           className="flex py-6 space-x-4 sm:space-x-24"
                         >
                           <div className="h-24 w-32 flex-shrink-0 overflow-hidden rounded-lg">
-                            <img
+                            <LazyLoadImage
                               src={`https://apis.spaceyatech.com${image}`}
                               alt={name}
                               className="h-full w-full object-cover object-center"
+                              effect="blur"
                             />
                           </div>
 

--- a/src/APP/pages/shop/SingleItemPage.jsx
+++ b/src/APP/pages/shop/SingleItemPage.jsx
@@ -15,6 +15,8 @@ import CartDrawer from "../../components/shop/CartDrawer";
 import Counter from "../../components/shop/Counter";
 import ItemHeader from "./sections/ItemHeader";
 
+import { LazyLoadImage } from "react-lazy-load-image-component";
+
 const products = [
   {
     id: 1,
@@ -100,15 +102,16 @@ export default function SingleItemPage() {
       {isSuccess ? (
         <div className="px-8 sm:px-0 m-auto mb-10 max-w-screen-2xl flex flex-col md:flex-row justify-between w-full space-y-4 md:space-x-28 text-[#323433]">
           <div className="md:pb-14 md:w-1/2 space-y-6">
-            <img
+            <LazyLoadImage
               src={singleSwag.image}
               alt={singleSwag.name}
               className="m-auto md:min-w-full "
+              effect="blur"
             />
             <div className="flex justify-between">
               {VariationData.map((pic) => (
                 <div key={crypto.randomUUID()} className="w-[70px] sm:w-auto">
-                  <img src={pic} alt="recommendation" />
+                  <LazyLoadImage src={pic} alt="recommendation" effect="blur" />
                 </div>
               ))}
             </div>
@@ -130,12 +133,13 @@ export default function SingleItemPage() {
             <div className="flex justify-start space-x-6">
               {VariationData.map((pic) => (
                 <div key={crypto.randomUUID()}>
-                  <img
+                  <LazyLoadImage
                     src={pic}
                     alt=""
                     height="96px"
                     width="96px"
                     className="rounded-full"
+                    effect="blur"
                   />
                 </div>
               ))}

--- a/src/APP/pages/shop/sections/CategoriesProducts.jsx
+++ b/src/APP/pages/shop/sections/CategoriesProducts.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useSwagList } from "../../../../hooks/Queries/shop/useSwagList";
 import ItemHeader from "./ItemHeader";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function CategoriesProducts() {
   const params = useParams();
@@ -101,10 +102,11 @@ function CategoriesProducts() {
                   to={`/shop/item/${product.id}`}
                 >
                   <div className="aspect-h-1 aspect-w-1 w-full overflow-hidden rounded-md bg-gray-200 lg:aspect-none group-hover:opacity-75 lg:h-80">
-                    <img
+                    <LazyLoadImage
                       src={product.image}
                       alt="Front of men&#039;s Basic Tee in black."
                       className="w-full h-60 object-cover object-center lg:h-full lg:w-full"
+                      effect="blur"
                     />
                   </div>
                   <div className="mt-4 flex justify-between">

--- a/src/APP/pages/shop/sections/CategoriesSection.jsx
+++ b/src/APP/pages/shop/sections/CategoriesSection.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useSwagList } from "../../../../hooks/Queries/shop/useSwagList";
 import ItemHeader from "./ItemHeader";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function CategoriesSection() {
   const [categories, setCategories] = useState([
@@ -86,10 +87,11 @@ function CategoriesSection() {
               className="w-60 lg:w-[420px] h-72 hover:opacity-75"
             >
               <Link to={`/shop/category/${category.name}`}>
-                <img
+                <LazyLoadImage
                   src={category.imgURL}
                   className="object-cover object-center rounded-2xl h-64 w-60 lg:w-[420px]"
                   alt={category.name}
+                  effect="blur"
                 />
               </Link>
               <div className="p-2 flex items-center justify-between">

--- a/src/APP/pages/shop/sections/ItemHeader.jsx
+++ b/src/APP/pages/shop/sections/ItemHeader.jsx
@@ -5,6 +5,7 @@ import { Fragment, useState } from "react";
 import { useLocation, useParams, Link } from "react-router-dom";
 import CartIcon from "../../../../assets/images/icons/cart-icon.svg";
 import { useSwagList } from "../../../../hooks/Queries/shop/useSwagList";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function ItemHeader({ show }) {
   const { pathname } = useLocation();
@@ -115,10 +116,11 @@ function ItemHeader({ show }) {
                                   selected ? "font-medium" : "font-normal"
                                 }`}
                               >
-                                <img
+                                <LazyLoadImage
                                   src={item.image}
                                   alt={item.name}
                                   className="h-12 w-12 rounded"
+                                  effect="blur"
                                 />{" "}
                                 <span>{item.name}</span>
                               </div>
@@ -147,7 +149,7 @@ function ItemHeader({ show }) {
           </div>
         )}
         <button type="button" className="ml-6 items-end" onClick={show}>
-          <img src={CartIcon} alt="cart" />
+          <LazyLoadImage src={CartIcon} alt="cart" effect="blur" />
         </button>
       </div>
     </div>

--- a/src/APP/pages/shop/sections/PopularItemsSection.jsx
+++ b/src/APP/pages/shop/sections/PopularItemsSection.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useSwagList } from "../../../../hooks/Queries/shop/useSwagList";
+import { LazyLoadImage } from "react-lazy-load-image-component";
 
 function PopularItemsSection() {
   const navigate = useNavigate();
@@ -23,10 +24,11 @@ function PopularItemsSection() {
                   onClick={() => navigate(`/shop/item/${id}`)}
                 >
                   <div className="aspect-h-1 aspect-w-1 w-full overflow-hidden rounded-md bg-gray-200 lg:aspect-none group-hover:opacity-75 lg:h-80">
-                    <img
+                    <LazyLoadImage
                       src={image}
                       alt={name}
                       className="w-full h-60 object-cover object-center lg:h-full lg:w-full"
+                      effect="blur"
                     />
                   </div>
                   <div className="mt-4 flex justify-between">


### PR DESCRIPTION
Images [lazy loading](https://www.cloudflare.com/learning/performance/what-is-lazy-loading/) using [react-lazy-load-image-component](https://www.npmjs.com/package/react-lazy-load-image-component).
All `<img/>` replaced with

```javascript
import { LazyLoadImage } from 'react-lazy-load-image-component'; // npm i react-lazy-load-image-component

<LazyLoadImage
    alt="..."
    effect="blur"
    src="..." />
```

