### PR TITLE
replace error500 component with err500 image

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "lint": "eslint --fix eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "vite --host",
+    "build": "tsc && vite build",
     "lint": "eslint --fix eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "prepare": "husky install",

--- a/src/APP/pages/landingPage/sections/OurEvents.jsx
+++ b/src/APP/pages/landingPage/sections/OurEvents.jsx
@@ -12,6 +12,8 @@ import {
 import { Loader, ViewMoreBtn } from "../../../components";
 import Error500 from "../../errorPages/Error500";
 import useTopEvents from "@/hooks/Queries/eventsSection/useTopEvents";
+import { LazyLoadImage } from "react-lazy-load-image-component";
+import { error500svg } from "../../../../assets/images/errorPages";
 
 function OurEvents() {
   const {
@@ -49,7 +51,19 @@ function OurEvents() {
           <ViewMoreBtn link="/all-events" />
         </div>
 
-        {isError && <Error500 />}
+        {isError && (
+          <div className="size-full flex-center flex-col gap-4">
+            <LazyLoadImage
+              src={error500svg}
+              alt="error-500"
+              effect="blur"
+              className="size-full md:size-[600px] object-cover"
+            />
+            <span className="text-red-500 text-base font-semibold">
+              Error fetching Events!
+            </span>
+          </div>
+        )}
         {isPending && (
           <div className="flex flex-col items-center justify-center gap-4 py-10">
             <Loader />

--- a/src/APP/pages/landingPage/sections/OurEvents.jsx
+++ b/src/APP/pages/landingPage/sections/OurEvents.jsx
@@ -65,7 +65,7 @@ function OurEvents() {
           </div>
         )}
         {isPending && (
-          <div className="flex flex-col items-center justify-center gap-4 py-10">
+          <div className="flex flex-col items-center justify-center size-full gap-4 py-10">
             <Loader />
             <p className="text-lg font-medium text-primary">
               Loading events...

--- a/src/assets/images/errorPages/index.js
+++ b/src/assets/images/errorPages/index.js
@@ -1,7 +1,7 @@
-import error400 from "./error-400.png";
-import error404 from "./error-404.svg";
-import error403 from "./error-403.png";
-import bgError500 from "./bg-error-500.png";
 import error500svg from "./500.svg";
+import bgError500 from "./bg-error-500.png";
+import error400 from "./error-400.png";
+import error403 from "./error-403.png";
+import error404 from "./error-404.svg";
 
 export { error400, error404, bgError500, error403, error500svg };


### PR DESCRIPTION
I noticed that the Error500 page is displayed inside the landing page if there is an error fetching event data. Instead of displaying the whole page, only the error image was displayed.

![Screenshot 2024-04-11 164844](https://github.com/SpaceyaTech/SYT-Web-Redesign/assets/68052150/eea81edb-b9d4-4816-b2ce-34666171ff80)

![Screenshot 2024-04-11 164914](https://github.com/SpaceyaTech/SYT-Web-Redesign/assets/68052150/e37446db-5cd3-43c1-814e-34b634b1d284)
