### PR TITLE
fix: terms & conditions footer link to notion page

### DIFF
--- a/src/APP/components/Footer.jsx
+++ b/src/APP/components/Footer.jsx
@@ -4,7 +4,6 @@
 import React from "react";
 import { LazyLoadImage } from "react-lazy-load-image-component";
 import { Link } from "react-router-dom";
-import Terms from "../../assets/documentation/terms-and-conditions.pdf";
 import {
   linkedin,
   twitter,
@@ -71,7 +70,7 @@ function Footer() {
       links: [
         { href: "https://x.com/SpaceYaTech", name: "Contact Us" },
         {
-          href: Terms,
+          href: "https://syt-terms.notion.site/SpaceYaTech-Terms-of-Service-7d84de7a4feb41cc9f86143a9cc572e0",
           name: "Terms and Conditions",
         },
       ],


### PR DESCRIPTION
Updated the Terms & Conditions footer link to point to the [notion page](https://syt-terms.notion.site/SpaceYaTech-Terms-of-Service-7d84de7a4feb41cc9f86143a9cc572e0)
Deleted the terms-and -conditions.pdf file in the documentation directory.

Fixes #166  