### PR TITLE
feat: add seo metadata to website pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-fast-marquee": "^1.6.2",
-    "react-helmet": "^6.1.0",
     "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.48.2",
     "react-hot-toast": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^18.2.0",
     "react-fast-marquee": "^1.6.2",
     "react-helmet": "^6.1.0",
+    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.48.2",
     "react-hot-toast": "^2.4.1",
     "react-lazy-load-image-component": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-fast-marquee": "^1.6.2",
+    "react-helmet": "^6.1.0",
     "react-hook-form": "^7.48.2",
     "react-hot-toast": "^2.4.1",
     "react-lazy-load-image-component": "^1.6.0",

--- a/src/APP/components/SeoMetadata.jsx
+++ b/src/APP/components/SeoMetadata.jsx
@@ -7,6 +7,7 @@ export default function SeoMetadata({
   url,
   ogImage = "https://apis.spaceyatech.com/media/blog-images/syt.png",
   ogImageAlt = "SpaceYaTech logo, social media handles, website URL, email, and more on a muted background.",
+  siteName = "SpaceYaTech",
 }) {
   return (
     <Helmet prioritizeSeoTags>
@@ -27,7 +28,7 @@ export default function SeoMetadata({
       <meta property="og:image:height" content="480" />
       <meta property="og:image:type" content="image/png" />
       <meta property="og:description" content={description} />
-      <meta property="og:site_name" content="SpaceYaTech" />
+      <meta property="og:site_name" content={siteName} />
       <meta property="og:locale" content="en_US" />
       <meta property="og:locale:alternate" content="en_GB" />
       {/* End Optional OG metadata tags */}

--- a/src/APP/components/SeoMetadata.jsx
+++ b/src/APP/components/SeoMetadata.jsx
@@ -1,0 +1,42 @@
+import { Helmet } from "react-helmet-async";
+
+export default function SeoMetadata({
+  title,
+  description,
+  type = "website",
+  url,
+  ogImage = "https://apis.spaceyatech.com/media/blog-images/syt.png",
+  ogImageAlt = "SpaceYaTech logo, social media handles, website URL, email, and more on a muted background.",
+}) {
+  return (
+    <Helmet prioritizeSeoTags>
+      {/* Standard metadata tags */}
+      <title>{`${title} - SpaceYaTech`}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      {/* End Standard metadata tags */}
+      {/* Standard OpenGraph metadata tags */}
+      <meta property="og:title" content={title} />
+      <meta property="og:type" content={type} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={ogImage} />
+      <meta property="og:image:alt" content={ogImageAlt} />
+      {/* End standard OG metadata tags */}
+      {/* Optional OG metadata tags */}
+      <meta property="og:image:width" content="1920" />
+      <meta property="og:image:height" content="480" />
+      <meta property="og:image:type" content="image/png" />
+      <meta property="og:description" content={description} />
+      <meta property="og:site_name" content="SpaceYaTech" />
+      <meta property="og:locale" content="en_US" />
+      <meta property="og:locale:alternate" content="en_GB" />
+      {/* End Optional OG metadata tags */}
+      {/* Twitter tags */}
+      <meta name="twitter:site" content="@SpaceYaTech" />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={`${title} - SpaceYaTech`} />
+      <meta name="twitter:description" content={description} />
+      {/* End Twitter tags */}
+    </Helmet>
+  );
+}

--- a/src/APP/components/SeoMetadata.jsx
+++ b/src/APP/components/SeoMetadata.jsx
@@ -26,7 +26,6 @@ export default function SeoMetadata({
       {/* Optional OG metadata tags */}
       <meta property="og:image:width" content="1920" />
       <meta property="og:image:height" content="480" />
-      <meta property="og:image:type" content="image/png" />
       <meta property="og:description" content={description} />
       <meta property="og:site_name" content={siteName} />
       <meta property="og:locale" content="en_US" />

--- a/src/APP/pages/aboutUs/AboutUs.jsx
+++ b/src/APP/pages/aboutUs/AboutUs.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-
+import SeoMetadata from "../../components/SeoMetadata";
 import {
   HeroSection,
   LeadershipSection,
@@ -13,12 +13,22 @@ function AboutUs() {
   }, []);
 
   return (
-    <div className="text-[#323433] max-w-[1440px] mx-auto">
-      <HeroSection />
-      <MissionVisionSection />
-      <LeadershipSection />
-      <PartnerCTA />
-    </div>
+    <>
+      <SeoMetadata
+        title="About Us"
+        description="A community fostering innovation across African borders for tech enthusiasts with memberships across Kenya, Tanzania, Nigeria and pockets of Africa."
+        type="website"
+        url="https://www.spaceyatech.com/about-us"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+      />
+      <div className="text-[#323433] max-w-[1440px] mx-auto">
+        <HeroSection />
+        <MissionVisionSection />
+        <LeadershipSection />
+        <PartnerCTA />
+      </div>
+    </>
   );
 }
 

--- a/src/APP/pages/blog2/Blog2.jsx
+++ b/src/APP/pages/blog2/Blog2.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import useBlogData from "../../../hooks/Queries/blog/useBlogData";
 import { Loader } from "../../components";
+import SeoMetadata from "../../components/SeoMetadata";
 import { Advert, BlogHeader, BlogBody } from "./sections";
 
 function Blog2() {
@@ -22,38 +23,49 @@ function Blog2() {
   }, [refetchBlogData, titleSlug]);
 
   return (
-    <div className="max-w-[1024px] mx-auto">
-      {isError && navigate("/error-500")}
+    <>
+      <SeoMetadata
+        title={blogData?.title}
+        description={blogData?.description}
+        type="article"
+        url={blogData?.title_slug}
+        ogImage={blogData?.image}
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+        siteName="SpaceYaTech Blog"
+      />
+      <div className="max-w-[1024px] mx-auto">
+        {isError && navigate("/error-500")}
 
-      {isLoading && (
-        <div className="flex flex-col items-center justify-center gap-4 py-10">
-          <Loader />
-          <p className="text-lg font-medium text-primary">
-            Loading blog details...
-          </p>
-        </div>
-      )}
-      {isSuccess && (
-        <>
-          <Advert />
-          <BlogHeader
-            title={blogData?.title}
-            description={blogData?.description}
-            image={blogData?.image}
-            author={blogData?.author}
-            createdAt={blogData?.created_at}
-            id={blogData?.id}
-            likes={blogData?.likes}
-            titleSlug={blogData?.title_slug}
-          />
-          <BlogBody
-            id={blogData?.id}
-            categoryId={blogData?.category.id}
-            blogBody={blogData?.body}
-          />
-        </>
-      )}
-    </div>
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center gap-4 py-10">
+            <Loader />
+            <p className="text-lg font-medium text-primary">
+              Loading blog details...
+            </p>
+          </div>
+        )}
+        {isSuccess && (
+          <>
+            <Advert />
+            <BlogHeader
+              title={blogData?.title}
+              description={blogData?.description}
+              image={blogData?.image}
+              author={blogData?.author}
+              createdAt={blogData?.created_at}
+              id={blogData?.id}
+              likes={blogData?.likes}
+              titleSlug={blogData?.title_slug}
+            />
+            <BlogBody
+              id={blogData?.id}
+              categoryId={blogData?.category.id}
+              blogBody={blogData?.body}
+            />
+          </>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/src/APP/pages/blogs/Blogs.jsx
+++ b/src/APP/pages/blogs/Blogs.jsx
@@ -1,13 +1,25 @@
 import React from "react";
 
+import SeoMetadata from "../../components/SeoMetadata";
 import { Banner, BlogsWrapper } from "./sections";
 
 function Blogs() {
   return (
-    <section className="flex flex-col items-center gap-4 max-w-[1440px] mx-auto">
-      <Banner />
-      <BlogsWrapper />
-    </section>
+    <>
+      <SeoMetadata
+        title="Blog"
+        description="SpaceYaTech Blog home page"
+        type="website"
+        url="https://www.spaceyatech.com/blogs"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+        siteName="SpaceYaTech Blog"
+      />
+      <section className="flex flex-col items-center gap-4 max-w-[1440px] mx-auto">
+        <Banner />
+        <BlogsWrapper />
+      </section>
+    </>
   );
 }
 

--- a/src/APP/pages/community/CommunityPage.jsx
+++ b/src/APP/pages/community/CommunityPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import SeoMetadata from "../../components/SeoMetadata";
 import EventsSection from "../events/sections/eventsSection/EventsSection";
 import { WelcomeSection, GallerySection } from "./sections";
 
@@ -8,13 +9,23 @@ function CommunityPage() {
   }, []);
 
   return (
-    <section className="bg-[#d9d9d9]/30 ">
-      <div className="max-w-[1440px] mx-auto">
-        <WelcomeSection />
-        <EventsSection showAllEventsLink />
-        <GallerySection />
-      </div>
-    </section>
+    <>
+      <SeoMetadata
+        title="Community"
+        description="SpaceYaTech is a dynamic tech community fostering career growth for young professionals across all tech sectors, offering networking and learning opportunities for all career stages."
+        type="website"
+        url="https://www.spaceyatech.com/community"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+      />
+      <section className="bg-[#d9d9d9]/30 ">
+        <div className="max-w-[1440px] mx-auto">
+          <WelcomeSection />
+          <EventsSection showAllEventsLink />
+          <GallerySection />
+        </div>
+      </section>
+    </>
   );
 }
 

--- a/src/APP/pages/community/sections/eventsPreview/SingleEvents/SingleEvent.jsx
+++ b/src/APP/pages/community/sections/eventsPreview/SingleEvents/SingleEvent.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
+import SeoMetadata from "../../../../../components/SeoMetadata";
 
 import { GoBackBtn, LandingWrapper, Loader } from "../../../../../components";
 import { EventDescription, Hero, SimilarEvents } from "./sections";
@@ -21,6 +22,13 @@ function SingleEvent() {
 
   return (
     <>
+      <SeoMetadata
+        title={`${oneEvent?.name} Event`}
+        description={oneEvent?.about}
+        type="website"
+        url={`https://spaceyatech.com/events/${oneEvent?.id}`}
+        siteName="SpaceYaTech"
+      />
       {isError && <p>Error fetching event!</p>}
       {isPending && (
         <div className="flex flex-col items-center justify-center gap-4 py-10">

--- a/src/APP/pages/events/pages/EventsPage.jsx
+++ b/src/APP/pages/events/pages/EventsPage.jsx
@@ -1,19 +1,29 @@
 import React from "react";
 
 import { GoBackBtn } from "../../../components";
+import SeoMetadata from "../../../components/SeoMetadata";
 import { EventsSection, FeaturedCarousel } from "../sections";
 
 function EventsPage() {
   return (
-    <section className="px-2 md:px-0 py-4 md:py-10 bg-gray-100">
-      <div className="max-w-1216 mx-auto flex flex-col gap-3 md:gap-6 w-full md:p-3">
-        <GoBackBtn />
+    <>
+      <SeoMetadata
+        title="Upcoming Events"
+        description="Upcoming tech events powered by SpaceYaTech."
+        type="website"
+        url="https://www.spaceyatech.com/events"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+      />
+      <section className="px-2 md:px-0 py-4 md:py-10 bg-gray-100">
+        <div className="max-w-1216 mx-auto flex flex-col gap-3 md:gap-6 w-full md:p-3">
+          <GoBackBtn />
+          <FeaturedCarousel />
 
-        <FeaturedCarousel />
-
-        <EventsSection />
-      </div>
-    </section>
+          <EventsSection />
+        </div>
+      </section>
+    </>
   );
 }
 

--- a/src/APP/pages/gallery/GalleryPage.jsx
+++ b/src/APP/pages/gallery/GalleryPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { arrowCircleLeft } from "../../../assets/images/icons";
 import processPhotos from "../../../utilities/processPhotos";
+import SeoMetadata from "../../components/SeoMetadata";
 import photosData from "./data";
 import ImageCard from "./sections/ImageCard";
 
@@ -11,33 +12,46 @@ function GalleryPage() {
   const photos = processPhotos(photosData);
 
   return (
-    <main className="bg-[#d9d9d9]/30 font-spaceGrotesk pb-12">
-      <div className="max-w-[1440px] mx-auto flex flex-col gap-8">
-        <div className="flex md:items-center flex-col md:flex-row gap-4 justify-between pt-8 pl-2 md:pl-0">
-          <Link
-            to="/community"
-            className="border rounded-full bg-white p-1 w-fit"
-          >
-            <div className="flex-center bg-green-light rounded-full px-3 py-1.5 gap-2">
-              <img src={arrowCircleLeft} alt="arrow-left" className="size-5" />
-              <span className="capitalize text-green-header text-sm font-semibold">
-                Go Back
-              </span>
-            </div>
-          </Link>
+    <>
+      <SeoMetadata
+        title="Gallery"
+        description="SpaceYaTech gallery collection"
+        type="website"
+        url="https://www.spaceyatech.com/gallery"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+      />
+      <main className="bg-[#d9d9d9]/30 font-spaceGrotesk pb-12">
+        <div className="max-w-[1440px] mx-auto flex flex-col gap-8">
+          <div className="flex md:items-center flex-col md:flex-row gap-4 justify-between pt-8 pl-2 md:pl-0">
+            <Link
+              to="/community"
+              className="border rounded-full bg-white p-1 w-fit"
+            >
+              <div className="flex-center bg-green-light rounded-full px-3 py-1.5 gap-2">
+                <img
+                  src={arrowCircleLeft}
+                  alt="arrow-left"
+                  className="size-5"
+                />
+                <span className="capitalize text-green-header text-sm font-semibold">
+                  Go Back
+                </span>
+              </div>
+            </Link>
 
-          <h1 className="text-base font-medium uppercase text-grey-neutral">
-            SpaceYaTech Gallery | Collection 2024
-          </h1>
-        </div>
+            <h1 className="text-base font-medium uppercase text-grey-neutral">
+              SpaceYaTech Gallery | Collection 2024
+            </h1>
+          </div>
 
-        {/* <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-0 grid-flow-dense">
+          {/* <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-0 grid-flow-dense">
           {photosData.map((photo) => (
             <ImageCard key={photo.id} photo={photo} />
           ))}
         </div> */}
 
-        {/* <div
+          {/* <div
           className="grid grid-cols-4 grid-rows-3 gap-4 grid-flow-dense"
           // style={{ gridAutoRows: "217px" }}
         >
@@ -71,7 +85,7 @@ function GalleryPage() {
           })}
         </div> */}
 
-        {/* <div
+          {/* <div
           className="grid grid-cols-4 grid-rows-3 grid-flow-dense gap-4"
           style={{ gridAutoRows: "108.5px" }}
         >
@@ -98,12 +112,13 @@ function GalleryPage() {
           </div>
         </div> */}
 
-        {/* Gallery library */}
-        <div className="overflow-y-auto h-full">
-          <ImageCard photos={photos} />
+          {/* Gallery library */}
+          <div className="overflow-y-auto h-full">
+            <ImageCard photos={photos} />
+          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </>
   );
 }
 

--- a/src/APP/pages/landingPage/LandingPage.jsx
+++ b/src/APP/pages/landingPage/LandingPage.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable import/no-unresolved */
 import LandingWrapper from "../../components/LandingWrapper";
+import SeoMetadata from "../../components/SeoMetadata";
 import {
   CTASection,
   FaqSection,
@@ -39,20 +40,30 @@ const components = [
 
 function LandingPage() {
   return (
-    <div className="w-screen bg-landingPageBg bg-gray-100">
-      <ScrollToTop />
-      <HeroSection />
-      <Partners />
-      <FeatureSection />
-      {components.map(({ component, title }) => (
-        <LandingWrapper key={title} title={title}>
-          {component}
-        </LandingWrapper>
-      ))}
-      <div className="p-2 pb-10 md:p-8 md:pb-20">
-        <CTASection />
+    <>
+      <SeoMetadata
+        title="Accelerating growth and potential of tech enthusiasts"
+        description="SpaceYaTech is the fastest growing Africa, open-source community looking to change the way young Africans get started in technology."
+        type="website"
+        url="https://www.spaceyatech.com/"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+      />
+      <div className="w-screen bg-landingPageBg bg-gray-100">
+        <ScrollToTop />
+        <HeroSection />
+        <Partners />
+        <FeatureSection />
+        {components.map(({ component, title }) => (
+          <LandingWrapper key={title} title={title}>
+            {component}
+          </LandingWrapper>
+        ))}
+        <div className="p-2 pb-10 md:p-8 md:pb-20">
+          <CTASection />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/APP/pages/products2/Products.jsx
+++ b/src/APP/pages/products2/Products.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import SeoMetadata from "../../components/SeoMetadata";
 import { HeroSection, ProductsSection, Teams, TechStack } from "./sections";
 
 const Products = () => {
@@ -6,12 +7,22 @@ const Products = () => {
     window.scrollTo(0, 0);
   }, []);
   return (
-    <section className="md:px-10 xl:max-w-[1440px] mx-auto">
-      <HeroSection />
-      <ProductsSection />
-      <TechStack />
-      <Teams />
-    </section>
+    <>
+      <SeoMetadata
+        title="Products"
+        description="A collection of products build by SpaceYaTech. We build products that work and look good."
+        type="website"
+        url="https://www.spaceyatech.com/products"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+      />
+      <section className="md:px-10 xl:max-w-[1440px] mx-auto">
+        <HeroSection />
+        <ProductsSection />
+        <TechStack />
+        <Teams />
+      </section>
+    </>
   );
 };
 

--- a/src/APP/pages/resources/Resources.jsx
+++ b/src/APP/pages/resources/Resources.jsx
@@ -1,12 +1,23 @@
+import SeoMetadata from "../../components/SeoMetadata";
 import { HeroSection, ResourcesSection } from "./sections";
 
 // million-ignore
 const Resources = () => {
   return (
-    <div className="px-4 md:px-10 md:pt-40 md:pb-8 pt-20 pb-6 flex flex-col gap-8 max-w-[1440px] mx-auto">
-      <HeroSection />
-      <ResourcesSection />
-    </div>
+    <>
+      <SeoMetadata
+        title="Resources"
+        description="Discover tech tools and resources to boost your productivity."
+        type="article"
+        url="https://www.spaceyatech.com/resources"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+      />
+      <div className="px-4 md:px-10 md:pt-40 md:pb-8 pt-20 pb-6 flex flex-col gap-8 max-w-[1440px] mx-auto">
+        <HeroSection />
+        <ResourcesSection />
+      </div>
+    </>
   );
 };
 

--- a/src/APP/pages/shop/Homepage.jsx
+++ b/src/APP/pages/shop/Homepage.jsx
@@ -1,3 +1,4 @@
+import SeoMetadata from "../../components/SeoMetadata";
 import Banner from "./sections/Banner";
 import CategoriesSection from "./sections/CategoriesSection";
 import PopularItemsSection from "./sections/PopularItemsSection";
@@ -5,12 +6,23 @@ import PopularItemsSection from "./sections/PopularItemsSection";
 
 function Homepage() {
   return (
-    <div>
-      <Banner />
-      <CategoriesSection />
-      {/* <CategoriesProducts/> */}
-      <PopularItemsSection />
-    </div>
+    <>
+      <SeoMetadata
+        title="Shop"
+        description="Elevate your style with our exclusive collection of merchandise."
+        type="article"
+        url="https://www.spaceyatech.com/shop"
+        ogImage="https://apis.spaceyatech.com/media/blog-images/syt.png"
+        ogImageAlt="SpaceYaTech logo, social media handles, website URL, email, and more on a muted background."
+        siteName="SpaceYaTech Shop"
+      />
+      <div>
+        <Banner />
+        <CategoriesSection />
+        {/* <CategoriesProducts/> */}
+        <PopularItemsSection />
+      </div>
+    </>
   );
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { HelmetProvider } from "react-helmet-async";
 import { Toaster } from "react-hot-toast";
 import { RouterProvider } from "react-router-dom";
 import "./index.css";
@@ -21,16 +22,18 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <Toaster position="top-right" reverseOrder={false} />
-      <AuthContextProvider>
-        <QueryClientProvider client={queryClient}>
-          <SearchBlogProvider>
-            <RouterProvider router={router} />
-            <ReactQueryDevtools position="bottom-right" />
-          </SearchBlogProvider>
-        </QueryClientProvider>
-      </AuthContextProvider>
-    </ErrorBoundary>
+    <HelmetProvider>
+      <ErrorBoundary>
+        <Toaster position="top-right" reverseOrder={false} />
+        <AuthContextProvider>
+          <QueryClientProvider client={queryClient}>
+            <SearchBlogProvider>
+              <RouterProvider router={router} />
+              <ReactQueryDevtools position="bottom-right" />
+            </SearchBlogProvider>
+          </QueryClientProvider>
+        </AuthContextProvider>
+      </ErrorBoundary>
+    </HelmetProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
This PR fixes #173 by adding main SEO metadata to website pages.

**Note:** I used `react-helment-async` instead of the now-deprecated `react-helmet` package (last updated in 2020). The former is also better since it fixes some memory leak and poor data integrity issues associated with `react-helmet`.

The metadata is included in one reusable component called `SeoMetadata`.  I've included some default values but every new page should import and use `SeoMetadata` component.

**Edits**
- Added info on the reusable component.