### PR TITLE
fixed isActive link on the navbar

### DIFF
--- a/src/APP/components/Header.jsx
+++ b/src/APP/components/Header.jsx
@@ -85,7 +85,8 @@ function Header() {
           style={showNavlinks ? { display: "flex" } : { display: "none" }}
         >
           {navLinks.map(({ link, id, route }) => {
-            const isActive = pathname === route;
+            const isActive =
+              pathname === route || pathname.startsWith(`${route}/`);
             return (
               <Link
                 key={id}
@@ -104,7 +105,8 @@ function Header() {
         {/* navlinks */}
         <nav className="md:flex hidden items-center gap-5 text-base">
           {navLinks.map(({ id, link, route }) => {
-            const isActive = pathname === route;
+            const isActive =
+              pathname === route || pathname.startsWith(`${route}/`);
             return (
               <Link
                 key={id}

--- a/src/APP/pages/events/sections/EventsSection.jsx
+++ b/src/APP/pages/events/sections/EventsSection.jsx
@@ -88,7 +88,7 @@ function EventsSection() {
         <div className="w-full flex items-center flex-col">
           <div className="flex items-center justify-between mb-6 gap-12">
             {isSuccess && (
-              <div className="flex items-center justify-center space-x-4 w-full md:w-fit mx-auto overflow-auto border border-red-400">
+              <div className="flex items-center justify-center space-x-4 w-full md:w-fit mx-auto overflow-auto">
                 {uniqueCategory.map((category) => (
                   <button
                     key={category}

--- a/src/APP/pages/events/sections/EventsSection.jsx
+++ b/src/APP/pages/events/sections/EventsSection.jsx
@@ -88,7 +88,7 @@ function EventsSection() {
         <div className="w-full flex items-center flex-col">
           <div className="flex items-center justify-between mb-6 gap-12">
             {isSuccess && (
-              <div className="flex items-center justify-center space-x-4 w-full sm:w-3/4 mx-auto overflow-auto">
+              <div className="flex items-center justify-center space-x-4 w-full md:w-fit mx-auto overflow-auto border border-red-400">
                 {uniqueCategory.map((category) => (
                   <button
                     key={category}


### PR DESCRIPTION
This fix adds the isActive on the sub-branches of the navlinks. An example, visiiting `/blogs/leveraging-open-source-to-boost-your-career-in-tech` will keep the `Blogs` navlink on the navbar active.