### PR TITLE
Limit events displayed on landing page to 6

### DIFF
--- a/src/APP/pages/events/sections/eventsSection/EventsSection.jsx
+++ b/src/APP/pages/events/sections/eventsSection/EventsSection.jsx
@@ -69,7 +69,7 @@ function EventsSection({ showTabs, showAllEventsLink }) {
         (topEventsData?.count === 0 ? (
           <p>Watch out for new events coming soon!</p>
         ) : (
-          <Events events={topEventsData?.results} />
+          <Events events={topEventsData?.results.slice(0, 6)} />
         ))}
       <div>
         <Link

--- a/src/APP/pages/landingPage/sections/OurEvents.jsx
+++ b/src/APP/pages/landingPage/sections/OurEvents.jsx
@@ -78,9 +78,11 @@ function OurEvents() {
             {topEvents?.count === 0 ? (
               <p className="">No events found!</p>
             ) : (
-              topEvents?.results.map((event) => (
-                <UpcomingEventCard key={event.id} event={event} />
-              ))
+              topEvents?.results
+                .slice(0, 6)
+                .map((event) => (
+                  <UpcomingEventCard key={event.id} event={event} />
+                ))
             )}
           </div>
         )}


### PR DESCRIPTION
Sliced the events displayed on the Landing and Community pages to 6 instead of 15.