### PR TITLE
fix: Link to event URL in single event view

### DIFF
--- a/src/pages/community/sections/eventsPreview/SingleEvents/sections/Hero.jsx
+++ b/src/pages/community/sections/eventsPreview/SingleEvents/sections/Hero.jsx
@@ -180,17 +180,19 @@ ${isVirtual ? "text-white" : "text-green-header"}
             </div>
           </div>
 
-          <button
-            type="button"
-            onClick={openModal}
+          <a
+            href={event?.link}
+            target="_blank"
+            rel="noreferrer"
+            // onClick={openModal}
             className={`py-2 px-20 rounded-lg ${
               isVirtual
                 ? "text-green-header bg-white"
                 : "text-white bg-gradient-to-b to-primary from-green-dark"
             }`}
           >
-            Reserve for Free
-          </button>
+            Reserve Tickets
+          </a>
         </div>
 
         <EventRSVP

--- a/src/pages/community/sections/eventsPreview/SingleEvents/sections/Hero.jsx
+++ b/src/pages/community/sections/eventsPreview/SingleEvents/sections/Hero.jsx
@@ -12,6 +12,7 @@ function Hero({ event }) {
 
   const [isOpen, setIsOpen] = useState(false);
 
+  // eslint-disable-next-line no-unused-vars
   function openModal() {
     setIsOpen(true);
   }


### PR DESCRIPTION
[Have you read the contributing guidelines ?](https://github.com/SpaceyaTech/SYT-Web-Redesign/blob/Dev/docs/CONTRIBUTING.md)

# What is the purpose of your _pull request_?

- [X] Bug fix
- [ ] New feature
- [ ] Documentation

# Proposed changes
As pointed out by Juma on WhatsApp, the frontend currently displays a reservation modal when a user clicks the `Reserve for Free` button in the single event page view.

This PR fixes that by taking the user to the event website from the api. I've also renamed the button text from `Reserve for Free` to `Reserve Tickets` since some events are paid (the api doesn't provide any info on whether the event is free or paid for now). 
## Further considerations
Since there's no differentiator on whether the event is ours or an external one, we can consider adding that marker to the api in the future and allow users to reserve tickets from the event page on our website for internal events.

# Warning

Please read these points carefully and answer honestly with an `X`
into all the boxes. Example : [X]

Before submitting a _pull request_ make sure you have:

- [x] Read the guidelines for contributing.
- [ ] Wrote some tests.
- [x] Respected the linting guidelines (read the guide below for help).

## How to Check and Fix Linting Issues

Run `npm run validate`. This command will run prettier and eslint checks to ensure linting guidelines are respected.

- If the command exits with code 0 (build is successful), there are no linting issues.

- If the command exits with a code other than 0, scroll up the command output and look for identified linting issues. Fix them and revalidate to check if the issues have been resolved by re-running the command.
