### PR TITLE
Feat: Formart event descriptions properly

### DIFF
--- a/src/pages/community/sections/eventsPreview/SingleEvents/sections/EventDescription.jsx
+++ b/src/pages/community/sections/eventsPreview/SingleEvents/sections/EventDescription.jsx
@@ -1,10 +1,11 @@
 import PropTypes from "prop-types";
 import React from "react";
+import formatEventDescription from "../../../../../../utilities/formatEventDescription";
 
 function EventDescription({ eventDesc }) {
   return (
-    <div className="w-full text-center max-w-3xl mx-auto text-sm md:text-[15px] md:leading-[22px] font-normal text-gray-600">
-      {eventDesc}
+    <div className="w-full max-w-3xl mx-auto text-sm md:text-[15px] md:leading-[22px] font-normal text-gray-600">
+      {formatEventDescription(eventDesc)}
     </div>
   );
 }

--- a/src/utilities/formatEventDescription.jsx
+++ b/src/utilities/formatEventDescription.jsx
@@ -1,0 +1,20 @@
+/* eslint-disable react/no-array-index-key */
+import React from "react";
+// .split("\r\n\r\n") Splits by paragraphs
+// .split("\r\n") splits by lines
+const formatEventDescription = (text) =>
+  text.split("\r\n\r\n").map((paragraph) => (
+    <p key={crypto.randomUUID()} className="leading-6 mb-4 whitespace-pre-wrap">
+      {paragraph.split("\r\n").map((line, i) => (
+        <React.Fragment key={i}>
+          {line}
+          {i < paragraph.split("\r\n").length - 1 && (
+            // Adds space between lines
+            <br className="mb-2" />
+          )}
+        </React.Fragment>
+      ))}
+    </p>
+  ));
+
+export default formatEventDescription;


### PR DESCRIPTION
[Have you read the contributing guidelines ?](https://github.com/SpaceyaTech/SYT-Web-Redesign/blob/Dev/docs/CONTRIBUTING.md)

# What is the purpose of your _pull request_?

- [ ] Bug fix
- [x] New feature
- [ ] Documentation

# Proposed changes

The website currently displays event descriptions as one giant paragraph with centered text as shown below. 

![before](https://github.com/user-attachments/assets/336950a9-8048-4c94-8511-153a69008470)

I've fixed this by adding a formatting utility function that takes the text and splits it into paragraphs using `\r\n\r\n` as the differentiator. I also format the individual text lines nicely (using `\r\n`as the separator) with sufficient spacing for easier reading as shown below.

![after](https://github.com/user-attachments/assets/85319d33-ebdc-4754-9877-36d5e04077c0)


# Warning

Please read these points carefully and answer honestly with an `X`
into all the boxes. Example : [X]

Before submitting a _pull request_ make sure you have:

- [x] Read the guidelines for contributing.
- [ ] Wrote some tests.
- [x] Respected the linting guidelines (read the guide below for help).

## How to Check and Fix Linting Issues

Run `npm run validate`. This command will run prettier and eslint checks to ensure linting guidelines are respected.

- If the command exits with code 0 (build is successful), there are no linting issues.

- If the command exits with a code other than 0, scroll up the command output and look for identified linting issues. Fix them and revalidate to check if the issues have been resolved by re-running the command.
